### PR TITLE
docs: remove "zero-dependency" branding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ xcuserdata/
 *.swo
 *.tmp
 *~
+
+.claude

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Discuss large changes or new public API in an issue before starting work.
   the project has `explicitApi()` enabled.
 - New public API must include KDoc documentation.
 - After adding or changing public API, run `./gradlew apiDump` and commit the updated `.api` files.
-- Do not add external dependencies to library modules — kstats is a **zero-dependency** library.
+- Do not add external dependencies to library modules.
 
 ### New Statistical Methods
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 # kstats
 
 A Kotlin Multiplatform statistics toolkit covering descriptive analysis, probability distributions, hypothesis testing,
-correlation, regression, and sampling. Zero dependencies, pure Kotlin, published to Maven Central as focused modules.
+correlation, regression, and sampling. Pure Kotlin, published to Maven Central as focused modules.
 
 ## Quickstart
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Introduction"
-description: "kstats is a zero-dependency Kotlin Multiplatform statistics library covering descriptive stats, distributions, hypothesis tests, correlation, and sampling."
+description: "kstats is a Kotlin Multiplatform statistics library covering descriptive stats, distributions, hypothesis tests, correlation, and sampling."
 ---
 
 [//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
 
-kstats is a zero-dependency Kotlin Multiplatform statistics library. It covers descriptive statistics, probability distributions, hypothesis testing, correlation and regression, and sampling — everything needed for quantitative analysis in Kotlin.
+kstats is a Kotlin Multiplatform statistics library. It covers descriptive statistics, probability distributions, hypothesis testing, correlation and regression, and sampling — everything needed for quantitative analysis in Kotlin.
 
 [//]: # (<!---FUN introOverview-->)
 

--- a/dokka/modules.md
+++ b/dokka/modules.md
@@ -5,7 +5,7 @@
 <!---IMPORT org.oremif.kstats.correlation.samples.DokkaSamples-->
 <!---IMPORT org.oremif.kstats.sampling.samples.DokkaSamples-->
 
-Zero-dependency Kotlin Multiplatform statistics library. All math is implemented from scratch
+Kotlin Multiplatform statistics library. All math is implemented from scratch
 in pure Kotlin common code — no platform-specific dependencies, no JVM-only numerics.
 Targets JVM, Android, iOS, macOS, watchOS, tvOS, Linux, Windows, JS, and Wasm.
 


### PR DESCRIPTION
## Description
kotlinx libraries don't advertise this, it's expected

## Testing

<!-- How was this tested? -->

## Checklist

- [ ] Existing tests pass
- [ ] New/updated tests for changed behavior
- [ ] New/updated documentation if necessary
