### PR TITLE
fix: regularizedBeta convergence failure for large parameters

### DIFF
--- a/kstats-core/src/commonMain/kotlin/org/oremif/kstats/core/MathUtils.kt
+++ b/kstats-core/src/commonMain/kotlin/org/oremif/kstats/core/MathUtils.kt
@@ -131,8 +131,11 @@ public fun beta(a: Double, b: Double): Double = exp(lnBeta(a, b))
 
 // ── Regularized incomplete beta function I_x(a, b) ─────────────────────────
 
-private const val BETA_MAX_ITERATIONS = 200
+private const val BETA_BASE_MAX_ITERATIONS = 200
 private const val BETA_EPSILON = 1e-14
+
+private fun betaMaxIterations(a: Double, b: Double): Int =
+    maxOf(BETA_BASE_MAX_ITERATIONS, (10.0 * sqrt(maxOf(a, b))).toInt())
 
 /**
  * Computes the regularized incomplete beta function I(x; a, b) at point [x].
@@ -152,7 +155,7 @@ private const val BETA_EPSILON = 1e-14
  * @param a the first shape parameter. Must be positive.
  * @param b the second shape parameter. Must be positive.
  * @return the regularized incomplete beta function value at [x], in the range [0, 1].
- * @throws org.oremif.kstats.core.exceptions.ConvergenceException if the continued fraction does not converge within 200 iterations.
+ * @throws org.oremif.kstats.core.exceptions.ConvergenceException if the continued fraction does not converge within the iteration limit.
  */
 public fun regularizedBeta(x: Double, a: Double, b: Double): Double {
     if (x.isNaN() || a.isNaN() || b.isNaN()) return Double.NaN
@@ -175,8 +178,9 @@ public fun regularizedBeta(x: Double, a: Double, b: Double): Double {
     d = 1.0 / d
     var result = d
 
+    val maxIter = betaMaxIterations(a, b)
     var converged = false
-    for (m in 1..BETA_MAX_ITERATIONS) {
+    for (m in 1..maxIter) {
         // even step
         val mDouble = m.toDouble()
         var numerator = mDouble * (b - mDouble) * x / ((a + 2.0 * mDouble - 1.0) * (a + 2.0 * mDouble))
@@ -205,8 +209,8 @@ public fun regularizedBeta(x: Double, a: Double, b: Double): Double {
         }
     }
 
-    checkConvergence(converged, BETA_MAX_ITERATIONS, prefactor * result) {
-        "regularizedBeta did not converge for x=$x, a=$a, b=$b after $BETA_MAX_ITERATIONS iterations"
+    checkConvergence(converged, maxIter, prefactor * result) {
+        "regularizedBeta did not converge for x=$x, a=$a, b=$b after $maxIter iterations"
     }
 
     return prefactor * result

--- a/kstats-core/src/commonMain/kotlin/org/oremif/kstats/core/MathUtils.kt
+++ b/kstats-core/src/commonMain/kotlin/org/oremif/kstats/core/MathUtils.kt
@@ -134,6 +134,7 @@ public fun beta(a: Double, b: Double): Double = exp(lnBeta(a, b))
 private const val BETA_BASE_MAX_ITERATIONS = 200
 private const val BETA_EPSILON = 1e-14
 
+/** Dynamic iteration limit for regularized beta — scales with sqrt(max(a, b)) for large shape parameters. */
 private fun betaMaxIterations(a: Double, b: Double): Int =
     maxOf(BETA_BASE_MAX_ITERATIONS, (10.0 * sqrt(maxOf(a, b))).toInt())
 

--- a/kstats-core/src/commonTest/kotlin/org/oremif/kstats/core/MathUtilsTest.kt
+++ b/kstats-core/src/commonTest/kotlin/org/oremif/kstats/core/MathUtilsTest.kt
@@ -90,6 +90,124 @@ class MathUtilsTest {
         assertEquals(0.6875, regularizedBeta(0.5, 2.0, 3.0), ITERATIVE_TOLERANCE)
     }
 
+    @Test
+    fun testRegularizedBetaLargeParametersRegression() {
+        // Regression: regularizedBeta with a ~ b ~ 145K previously threw ConvergenceException
+        // because the fixed 200-iteration limit was insufficient. The fix adds dynamic iteration
+        // limits via betaMaxIterations(a, b) = max(200, floor(10 * sqrt(max(a, b)))).
+        // scipy: special.betainc(145274.0, 145311.0, 0.4999) = 0.484375989852313
+        val result = regularizedBeta(0.4999, 145274.0, 145311.0)
+        assertTrue(result.isFinite(), "regularizedBeta should not throw for a=145274, b=145311")
+        assertEquals(0.484375989852313, result, 1e-6, "betainc(145274, 145311, 0.4999)")
+
+        // scipy: special.betainc(145274.0, 145311.0, 0.5) = 0.527361185858317
+        val result2 = regularizedBeta(0.5, 145274.0, 145311.0)
+        assertTrue(result2.isFinite(), "regularizedBeta(0.5, 145274, 145311) should be finite")
+        assertEquals(0.527361185858317, result2, 1e-6, "betainc(145274, 145311, 0.5)")
+    }
+
+    @Test
+    fun testRegularizedBetaLargeParametersKnownValues() {
+        // scipy: special.betainc(1000, 1000, 0.5) = 0.499999999999999
+        assertEquals(0.5, regularizedBeta(0.5, 1000.0, 1000.0), 1e-6)
+        // scipy: special.betainc(1000, 1000, 0.49) = 0.185552659431512
+        assertEquals(0.185552659431512, regularizedBeta(0.49, 1000.0, 1000.0), 1e-6)
+        // scipy: special.betainc(1000, 1000, 0.51) = 0.814447340568488
+        assertEquals(0.814447340568488, regularizedBeta(0.51, 1000.0, 1000.0), 1e-6)
+        // scipy: special.betainc(10000, 10000, 0.5) = 0.5
+        assertEquals(0.5, regularizedBeta(0.5, 10000.0, 10000.0), 1e-6)
+        // scipy: special.betainc(10000, 10000, 0.499) = 0.388649952142536
+        assertEquals(0.388649952142536, regularizedBeta(0.499, 10000.0, 10000.0), 1e-6)
+    }
+
+    @Test
+    fun testRegularizedBetaVeryLargeParameters() {
+        // Numerical stability with very large shape parameters
+        // scipy: special.betainc(50000, 50000, 0.5) = 0.5
+        assertEquals(0.5, regularizedBeta(0.5, 50000.0, 50000.0), 1e-6)
+        // scipy: special.betainc(50000, 50000, 0.4999) = 0.474785548275951
+        assertEquals(0.474785548275951, regularizedBeta(0.4999, 50000.0, 50000.0), 1e-6)
+        // scipy: special.betainc(100000, 100000, 0.5) = 0.5
+        assertEquals(0.5, regularizedBeta(0.5, 100000.0, 100000.0), 1e-6)
+        // scipy: special.betainc(100000, 100000, 0.4999) = 0.464365081352024
+        assertEquals(0.464365081352024, regularizedBeta(0.4999, 100000.0, 100000.0), 1e-6)
+        // scipy: special.betainc(200000, 200000, 0.5) = 0.5
+        assertEquals(0.5, regularizedBeta(0.5, 200000.0, 200000.0), 1e-6)
+        // scipy: special.betainc(200000, 200000, 0.4999) = 0.44967162506792
+        assertEquals(0.44967162506792, regularizedBeta(0.4999, 200000.0, 200000.0), 1e-6)
+    }
+
+    @Test
+    fun testRegularizedBetaLargeParamsSymmetryProperty() {
+        // Property: I_x(a, b) + I_{1-x}(b, a) = 1 for all valid x, a, b
+        val cases = listOf(
+            Triple(0.4999, 145274.0, 145311.0),
+            Triple(0.499, 10000.0, 10000.0),
+            Triple(0.4999, 50000.0, 50000.0),
+            Triple(0.5, 1000.0, 1000.0),
+        )
+        for ((x, a, b) in cases) {
+            val left = regularizedBeta(x, a, b)
+            val right = regularizedBeta(1.0 - x, b, a)
+            assertEquals(
+                1.0, left + right, 1e-6,
+                "I_$x($a,$b) + I_${1.0 - x}($b,$a) should equal 1"
+            )
+        }
+    }
+
+    @Test
+    fun testRegularizedBetaLargeParamsMonotonicity() {
+        // Property: regularizedBeta(x, a, b) is monotonically increasing in x
+        val a = 10000.0
+        val b = 10000.0
+        val xs = listOf(0.48, 0.49, 0.495, 0.499, 0.5, 0.501, 0.505, 0.51, 0.52)
+        var prev = regularizedBeta(xs[0], a, b)
+        for (i in 1 until xs.size) {
+            val curr = regularizedBeta(xs[i], a, b)
+            assertTrue(
+                curr >= prev,
+                "regularizedBeta should be monotonic: I_${xs[i]}($a,$b) = $curr >= I_${xs[i - 1]}($a,$b) = $prev"
+            )
+            prev = curr
+        }
+    }
+
+    @Test
+    fun testRegularizedBetaLargeParamsRange() {
+        // Property: result must be in [0, 1] for any valid inputs including large params
+        val cases = listOf(
+            Triple(0.4999, 145274.0, 145311.0),
+            Triple(0.5, 145274.0, 145311.0),
+            Triple(0.5, 100000.0, 100000.0),
+            Triple(0.4999, 200000.0, 200000.0),
+        )
+        for ((x, a, b) in cases) {
+            val result = regularizedBeta(x, a, b)
+            assertTrue(result in 0.0..1.0, "regularizedBeta($x, $a, $b) = $result should be in [0, 1]")
+        }
+    }
+
+    @Test
+    fun testRegularizedBetaNaNPropagation() {
+        assertTrue(regularizedBeta(Double.NaN, 2.0, 3.0).isNaN(), "NaN x")
+        assertTrue(regularizedBeta(0.5, Double.NaN, 3.0).isNaN(), "NaN a")
+        assertTrue(regularizedBeta(0.5, 2.0, Double.NaN).isNaN(), "NaN b")
+    }
+
+    @Test
+    fun testRegularizedBetaInvalidParameters() {
+        assertFailsWith<InvalidParameterException> {
+            regularizedBeta(0.5, -1.0, 3.0)
+        }
+        assertFailsWith<InvalidParameterException> {
+            regularizedBeta(0.5, 2.0, 0.0)
+        }
+        assertFailsWith<InvalidParameterException> {
+            regularizedBeta(0.5, 0.0, 3.0)
+        }
+    }
+
     // ── Regularized gamma ───────────────────────────────────────────────
 
     @Test

--- a/kstats-hypothesis/src/commonTest/kotlin/org/oremif/kstats/hypothesis/BinomialTestTest.kt
+++ b/kstats-hypothesis/src/commonTest/kotlin/org/oremif/kstats/hypothesis/BinomialTestTest.kt
@@ -814,4 +814,57 @@ class BinomialTestTest {
         // upper is clamped to 1.0 since raw value would exceed 1
         assertEquals(1.0, ci.upper, 1e-10, "AC 9999/10000 upper (clamped)")
     }
+
+    // ===== Regression: very large trials (regularizedBeta convergence) =====
+
+    @Test
+    fun testVeryLargeTrialsRegression() {
+        // Regression: binomialTest with ~290K trials previously threw ConvergenceException
+        // in regularizedBeta because the fixed 200-iteration limit was insufficient.
+        // The fix adds dynamic iteration limits via betaMaxIterations(a, b).
+        // scipy: binomtest(145274, 290585, 0.5)
+        // statistic = 0.499936335323571, pvalue = 0.946754474820775
+        val result = binomialTest(successes = 145274, trials = 290585, probability = 0.5)
+        assertEquals(0.499936335323571, result.statistic, 1e-10, "statistic for 145274/290585")
+        assertP(0.946754474820775, result.pValue, tol = 1e-4, message = "145274/290585 two-sided")
+        assertFalse(result.isSignificant(), "145274/290585 should not be significant at 5%")
+    }
+
+    @Test
+    fun testVeryLargeTrialsAlternatives() {
+        // scipy: binomtest(145274, 290585, 0.5, alternative='less') pvalue = 0.473377237410387
+        val less = binomialTest(
+            successes = 145274, trials = 290585, probability = 0.5,
+            alternative = Alternative.LESS
+        )
+        assertP(0.473377237410387, less.pValue, tol = 1e-4, message = "145274/290585 less")
+
+        // scipy: binomtest(145274, 290585, 0.5, alternative='greater') pvalue = 0.528099421105053
+        val greater = binomialTest(
+            successes = 145274, trials = 290585, probability = 0.5,
+            alternative = Alternative.GREATER
+        )
+        assertP(0.528099421105053, greater.pValue, tol = 1e-4, message = "145274/290585 greater")
+
+        // Same statistic regardless of alternative
+        assertEquals(less.statistic, greater.statistic, 1e-14, "statistic unchanged by alternative")
+    }
+
+    @Test
+    fun testVeryLargeTrialsClopperPearsonCI() {
+        // scipy: binomtest(145274, 290585, 0.5).proportion_ci(0.95, method='exact')
+        // CI: (0.498116674717248, 0.501755997199567)
+        val result = binomialTest(successes = 145274, trials = 290585, probability = 0.5)
+        assertCI(
+            0.498116674717248, 0.501755997199567,
+            result.confidenceInterval, tol = 1e-4, message = "CP CI 145274/290585"
+        )
+    }
+
+    @Test
+    fun testVeryLargeTrialsPValueRange() {
+        // Property: p-value must be in [0, 1] for very large trials
+        val result = binomialTest(successes = 145274, trials = 290585, probability = 0.5)
+        assertTrue(result.pValue in 0.0..1.0, "p-value should be in [0, 1], got ${result.pValue}")
+    }
 }

--- a/kstats-hypothesis/src/commonTest/kotlin/org/oremif/kstats/hypothesis/BinomialTestTest.kt
+++ b/kstats-hypothesis/src/commonTest/kotlin/org/oremif/kstats/hypothesis/BinomialTestTest.kt
@@ -826,7 +826,7 @@ class BinomialTestTest {
         // statistic = 0.499936335323571, pvalue = 0.946754474820775
         val result = binomialTest(successes = 145274, trials = 290585, probability = 0.5)
         assertEquals(0.499936335323571, result.statistic, 1e-10, "statistic for 145274/290585")
-        assertP(0.946754474820775, result.pValue, tol = 1e-4, message = "145274/290585 two-sided")
+        assertP(0.946754474820775, result.pValue, tol = 1e-6, message = "145274/290585 two-sided")
         assertFalse(result.isSignificant(), "145274/290585 should not be significant at 5%")
     }
 
@@ -837,14 +837,14 @@ class BinomialTestTest {
             successes = 145274, trials = 290585, probability = 0.5,
             alternative = Alternative.LESS
         )
-        assertP(0.473377237410387, less.pValue, tol = 1e-4, message = "145274/290585 less")
+        assertP(0.473377237410387, less.pValue, tol = 1e-6, message = "145274/290585 less")
 
         // scipy: binomtest(145274, 290585, 0.5, alternative='greater') pvalue = 0.528099421105053
         val greater = binomialTest(
             successes = 145274, trials = 290585, probability = 0.5,
             alternative = Alternative.GREATER
         )
-        assertP(0.528099421105053, greater.pValue, tol = 1e-4, message = "145274/290585 greater")
+        assertP(0.528099421105053, greater.pValue, tol = 1e-6, message = "145274/290585 greater")
 
         // Same statistic regardless of alternative
         assertEquals(less.statistic, greater.statistic, 1e-14, "statistic unchanged by alternative")
@@ -857,7 +857,7 @@ class BinomialTestTest {
         val result = binomialTest(successes = 145274, trials = 290585, probability = 0.5)
         assertCI(
             0.498116674717248, 0.501755997199567,
-            result.confidenceInterval, tol = 1e-4, message = "CP CI 145274/290585"
+            result.confidenceInterval, tol = 1e-6, message = "CP CI 145274/290585"
         )
     }
 


### PR DESCRIPTION
## Description

Add dynamic iteration limit `betaMaxIterations(a, b)` to `regularizedBeta`, matching the existing
`gammaMaxIterations` pattern. The fixed 200-iteration limit was insufficient for large, nearly-equal
parameters (a ≈ b ≈ 145K), causing `ConvergenceException` in `binomialTest` for A/B testing
scenarios.

Fixes #93

## Testing

`./gradlew :kstats-core:jvmTest :kstats-hypothesis:jvmTest`

## Checklist

- [x] Existing tests pass
- [x] New/updated tests for changed behavior
- [ ] New/updated documentation if necessary