### PR TITLE
feat: add control chart support (x-bar, R, S charts) with SPC constants

### DIFF
--- a/kstats-core/api/jvm/kstats-core.api
+++ b/kstats-core/api/jvm/kstats-core.api
@@ -87,6 +87,27 @@ public final class org/oremif/kstats/descriptive/CentralTendencyKt {
 	public static final fun weightedMean ([D[D)D
 }
 
+public final class org/oremif/kstats/descriptive/ControlChartKt {
+	public static final fun spcConstants (I)Lorg/oremif/kstats/descriptive/SpcConstants;
+	public static final fun xBarRChart (Ljava/util/List;)Lorg/oremif/kstats/descriptive/XBarRChartResult;
+	public static final fun xBarSChart (Ljava/util/List;)Lorg/oremif/kstats/descriptive/XBarSChartResult;
+}
+
+public final class org/oremif/kstats/descriptive/ControlChartLimits {
+	public fun <init> (DDD)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun copy (DDD)Lorg/oremif/kstats/descriptive/ControlChartLimits;
+	public static synthetic fun copy$default (Lorg/oremif/kstats/descriptive/ControlChartLimits;DDDILjava/lang/Object;)Lorg/oremif/kstats/descriptive/ControlChartLimits;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCenterLine ()D
+	public final fun getLcl ()D
+	public final fun getUcl ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/oremif/kstats/descriptive/DescriptiveStatistics {
 	public fun <init> (JDDDDDDDDDDDDDD)V
 	public final fun component1 ()J
@@ -395,8 +416,65 @@ public final class org/oremif/kstats/descriptive/ShapeKt {
 	public static synthetic fun skewness$default ([DLorg/oremif/kstats/descriptive/PopulationKind;ILjava/lang/Object;)D
 }
 
+public final class org/oremif/kstats/descriptive/SpcConstants {
+	public fun <init> (DDDDDDD)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun component4 ()D
+	public final fun component5 ()D
+	public final fun component6 ()D
+	public final fun component7 ()D
+	public final fun copy (DDDDDDD)Lorg/oremif/kstats/descriptive/SpcConstants;
+	public static synthetic fun copy$default (Lorg/oremif/kstats/descriptive/SpcConstants;DDDDDDDILjava/lang/Object;)Lorg/oremif/kstats/descriptive/SpcConstants;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getA2 ()D
+	public final fun getA3 ()D
+	public final fun getB3 ()D
+	public final fun getB4 ()D
+	public final fun getC4 ()D
+	public final fun getD3 ()D
+	public final fun getD4 ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/oremif/kstats/descriptive/SummaryStatisticsKt {
 	public static final fun describe (Ljava/lang/Iterable;)Lorg/oremif/kstats/descriptive/DescriptiveStatistics;
 	public static final fun describe ([D)Lorg/oremif/kstats/descriptive/DescriptiveStatistics;
+}
+
+public final class org/oremif/kstats/descriptive/XBarRChartResult {
+	public fun <init> (DDDLorg/oremif/kstats/descriptive/ControlChartLimits;)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun component4 ()Lorg/oremif/kstats/descriptive/ControlChartLimits;
+	public final fun copy (DDDLorg/oremif/kstats/descriptive/ControlChartLimits;)Lorg/oremif/kstats/descriptive/XBarRChartResult;
+	public static synthetic fun copy$default (Lorg/oremif/kstats/descriptive/XBarRChartResult;DDDLorg/oremif/kstats/descriptive/ControlChartLimits;ILjava/lang/Object;)Lorg/oremif/kstats/descriptive/XBarRChartResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCenterLine ()D
+	public final fun getLcl ()D
+	public final fun getRChart ()Lorg/oremif/kstats/descriptive/ControlChartLimits;
+	public final fun getUcl ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/oremif/kstats/descriptive/XBarSChartResult {
+	public fun <init> (DDDLorg/oremif/kstats/descriptive/ControlChartLimits;)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun component4 ()Lorg/oremif/kstats/descriptive/ControlChartLimits;
+	public final fun copy (DDDLorg/oremif/kstats/descriptive/ControlChartLimits;)Lorg/oremif/kstats/descriptive/XBarSChartResult;
+	public static synthetic fun copy$default (Lorg/oremif/kstats/descriptive/XBarSChartResult;DDDLorg/oremif/kstats/descriptive/ControlChartLimits;ILjava/lang/Object;)Lorg/oremif/kstats/descriptive/XBarSChartResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCenterLine ()D
+	public final fun getLcl ()D
+	public final fun getSChart ()Lorg/oremif/kstats/descriptive/ControlChartLimits;
+	public final fun getUcl ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/kstats-core/api/jvm/kstats-core.api
+++ b/kstats-core/api/jvm/kstats-core.api
@@ -457,6 +457,7 @@ public final class org/oremif/kstats/descriptive/XBarRChartResult {
 	public final fun getLcl ()D
 	public final fun getRChart ()Lorg/oremif/kstats/descriptive/ControlChartLimits;
 	public final fun getUcl ()D
+	public final fun getXBarChart ()Lorg/oremif/kstats/descriptive/ControlChartLimits;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -474,6 +475,7 @@ public final class org/oremif/kstats/descriptive/XBarSChartResult {
 	public final fun getLcl ()D
 	public final fun getSChart ()Lorg/oremif/kstats/descriptive/ControlChartLimits;
 	public final fun getUcl ()D
+	public final fun getXBarChart ()Lorg/oremif/kstats/descriptive/ControlChartLimits;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/kstats-core/api/kstats-core.klib.api
+++ b/kstats-core/api/kstats-core.klib.api
@@ -304,6 +304,8 @@ final class org.oremif.kstats.descriptive/XBarRChartResult { // org.oremif.kstat
         final fun <get-rChart>(): org.oremif.kstats.descriptive/ControlChartLimits // org.oremif.kstats.descriptive/XBarRChartResult.rChart.<get-rChart>|<get-rChart>(){}[0]
     final val ucl // org.oremif.kstats.descriptive/XBarRChartResult.ucl|{}ucl[0]
         final fun <get-ucl>(): kotlin/Double // org.oremif.kstats.descriptive/XBarRChartResult.ucl.<get-ucl>|<get-ucl>(){}[0]
+    final val xBarChart // org.oremif.kstats.descriptive/XBarRChartResult.xBarChart|{}xBarChart[0]
+        final fun <get-xBarChart>(): org.oremif.kstats.descriptive/ControlChartLimits // org.oremif.kstats.descriptive/XBarRChartResult.xBarChart.<get-xBarChart>|<get-xBarChart>(){}[0]
 
     final fun component1(): kotlin/Double // org.oremif.kstats.descriptive/XBarRChartResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // org.oremif.kstats.descriptive/XBarRChartResult.component2|component2(){}[0]
@@ -326,6 +328,8 @@ final class org.oremif.kstats.descriptive/XBarSChartResult { // org.oremif.kstat
         final fun <get-sChart>(): org.oremif.kstats.descriptive/ControlChartLimits // org.oremif.kstats.descriptive/XBarSChartResult.sChart.<get-sChart>|<get-sChart>(){}[0]
     final val ucl // org.oremif.kstats.descriptive/XBarSChartResult.ucl|{}ucl[0]
         final fun <get-ucl>(): kotlin/Double // org.oremif.kstats.descriptive/XBarSChartResult.ucl.<get-ucl>|<get-ucl>(){}[0]
+    final val xBarChart // org.oremif.kstats.descriptive/XBarSChartResult.xBarChart|{}xBarChart[0]
+        final fun <get-xBarChart>(): org.oremif.kstats.descriptive/ControlChartLimits // org.oremif.kstats.descriptive/XBarSChartResult.xBarChart.<get-xBarChart>|<get-xBarChart>(){}[0]
 
     final fun component1(): kotlin/Double // org.oremif.kstats.descriptive/XBarSChartResult.component1|component1(){}[0]
     final fun component2(): kotlin/Double // org.oremif.kstats.descriptive/XBarSChartResult.component2|component2(){}[0]

--- a/kstats-core/api/kstats-core.klib.api
+++ b/kstats-core/api/kstats-core.klib.api
@@ -142,6 +142,25 @@ final class org.oremif.kstats.core/ConfidenceInterval { // org.oremif.kstats.cor
     final fun toString(): kotlin/String // org.oremif.kstats.core/ConfidenceInterval.toString|toString(){}[0]
 }
 
+final class org.oremif.kstats.descriptive/ControlChartLimits { // org.oremif.kstats.descriptive/ControlChartLimits|null[0]
+    constructor <init>(kotlin/Double, kotlin/Double, kotlin/Double) // org.oremif.kstats.descriptive/ControlChartLimits.<init>|<init>(kotlin.Double;kotlin.Double;kotlin.Double){}[0]
+
+    final val centerLine // org.oremif.kstats.descriptive/ControlChartLimits.centerLine|{}centerLine[0]
+        final fun <get-centerLine>(): kotlin/Double // org.oremif.kstats.descriptive/ControlChartLimits.centerLine.<get-centerLine>|<get-centerLine>(){}[0]
+    final val lcl // org.oremif.kstats.descriptive/ControlChartLimits.lcl|{}lcl[0]
+        final fun <get-lcl>(): kotlin/Double // org.oremif.kstats.descriptive/ControlChartLimits.lcl.<get-lcl>|<get-lcl>(){}[0]
+    final val ucl // org.oremif.kstats.descriptive/ControlChartLimits.ucl|{}ucl[0]
+        final fun <get-ucl>(): kotlin/Double // org.oremif.kstats.descriptive/ControlChartLimits.ucl.<get-ucl>|<get-ucl>(){}[0]
+
+    final fun component1(): kotlin/Double // org.oremif.kstats.descriptive/ControlChartLimits.component1|component1(){}[0]
+    final fun component2(): kotlin/Double // org.oremif.kstats.descriptive/ControlChartLimits.component2|component2(){}[0]
+    final fun component3(): kotlin/Double // org.oremif.kstats.descriptive/ControlChartLimits.component3|component3(){}[0]
+    final fun copy(kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ...): org.oremif.kstats.descriptive/ControlChartLimits // org.oremif.kstats.descriptive/ControlChartLimits.copy|copy(kotlin.Double;kotlin.Double;kotlin.Double){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // org.oremif.kstats.descriptive/ControlChartLimits.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // org.oremif.kstats.descriptive/ControlChartLimits.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // org.oremif.kstats.descriptive/ControlChartLimits.toString|toString(){}[0]
+}
+
 final class org.oremif.kstats.descriptive/DescriptiveStatistics { // org.oremif.kstats.descriptive/DescriptiveStatistics|null[0]
     constructor <init>(kotlin/Long, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double) // org.oremif.kstats.descriptive/DescriptiveStatistics.<init>|<init>(kotlin.Long;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double){}[0]
 
@@ -241,6 +260,81 @@ final class org.oremif.kstats.descriptive/ProcessCapabilityResult { // org.oremi
     final fun equals(kotlin/Any?): kotlin/Boolean // org.oremif.kstats.descriptive/ProcessCapabilityResult.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // org.oremif.kstats.descriptive/ProcessCapabilityResult.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // org.oremif.kstats.descriptive/ProcessCapabilityResult.toString|toString(){}[0]
+}
+
+final class org.oremif.kstats.descriptive/SpcConstants { // org.oremif.kstats.descriptive/SpcConstants|null[0]
+    constructor <init>(kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double) // org.oremif.kstats.descriptive/SpcConstants.<init>|<init>(kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double){}[0]
+
+    final val a2 // org.oremif.kstats.descriptive/SpcConstants.a2|{}a2[0]
+        final fun <get-a2>(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.a2.<get-a2>|<get-a2>(){}[0]
+    final val a3 // org.oremif.kstats.descriptive/SpcConstants.a3|{}a3[0]
+        final fun <get-a3>(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.a3.<get-a3>|<get-a3>(){}[0]
+    final val b3 // org.oremif.kstats.descriptive/SpcConstants.b3|{}b3[0]
+        final fun <get-b3>(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.b3.<get-b3>|<get-b3>(){}[0]
+    final val b4 // org.oremif.kstats.descriptive/SpcConstants.b4|{}b4[0]
+        final fun <get-b4>(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.b4.<get-b4>|<get-b4>(){}[0]
+    final val c4 // org.oremif.kstats.descriptive/SpcConstants.c4|{}c4[0]
+        final fun <get-c4>(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.c4.<get-c4>|<get-c4>(){}[0]
+    final val d3 // org.oremif.kstats.descriptive/SpcConstants.d3|{}d3[0]
+        final fun <get-d3>(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.d3.<get-d3>|<get-d3>(){}[0]
+    final val d4 // org.oremif.kstats.descriptive/SpcConstants.d4|{}d4[0]
+        final fun <get-d4>(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.d4.<get-d4>|<get-d4>(){}[0]
+
+    final fun component1(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.component1|component1(){}[0]
+    final fun component2(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.component2|component2(){}[0]
+    final fun component3(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.component3|component3(){}[0]
+    final fun component4(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.component4|component4(){}[0]
+    final fun component5(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.component5|component5(){}[0]
+    final fun component6(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.component6|component6(){}[0]
+    final fun component7(): kotlin/Double // org.oremif.kstats.descriptive/SpcConstants.component7|component7(){}[0]
+    final fun copy(kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ...): org.oremif.kstats.descriptive/SpcConstants // org.oremif.kstats.descriptive/SpcConstants.copy|copy(kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // org.oremif.kstats.descriptive/SpcConstants.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // org.oremif.kstats.descriptive/SpcConstants.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // org.oremif.kstats.descriptive/SpcConstants.toString|toString(){}[0]
+}
+
+final class org.oremif.kstats.descriptive/XBarRChartResult { // org.oremif.kstats.descriptive/XBarRChartResult|null[0]
+    constructor <init>(kotlin/Double, kotlin/Double, kotlin/Double, org.oremif.kstats.descriptive/ControlChartLimits) // org.oremif.kstats.descriptive/XBarRChartResult.<init>|<init>(kotlin.Double;kotlin.Double;kotlin.Double;org.oremif.kstats.descriptive.ControlChartLimits){}[0]
+
+    final val centerLine // org.oremif.kstats.descriptive/XBarRChartResult.centerLine|{}centerLine[0]
+        final fun <get-centerLine>(): kotlin/Double // org.oremif.kstats.descriptive/XBarRChartResult.centerLine.<get-centerLine>|<get-centerLine>(){}[0]
+    final val lcl // org.oremif.kstats.descriptive/XBarRChartResult.lcl|{}lcl[0]
+        final fun <get-lcl>(): kotlin/Double // org.oremif.kstats.descriptive/XBarRChartResult.lcl.<get-lcl>|<get-lcl>(){}[0]
+    final val rChart // org.oremif.kstats.descriptive/XBarRChartResult.rChart|{}rChart[0]
+        final fun <get-rChart>(): org.oremif.kstats.descriptive/ControlChartLimits // org.oremif.kstats.descriptive/XBarRChartResult.rChart.<get-rChart>|<get-rChart>(){}[0]
+    final val ucl // org.oremif.kstats.descriptive/XBarRChartResult.ucl|{}ucl[0]
+        final fun <get-ucl>(): kotlin/Double // org.oremif.kstats.descriptive/XBarRChartResult.ucl.<get-ucl>|<get-ucl>(){}[0]
+
+    final fun component1(): kotlin/Double // org.oremif.kstats.descriptive/XBarRChartResult.component1|component1(){}[0]
+    final fun component2(): kotlin/Double // org.oremif.kstats.descriptive/XBarRChartResult.component2|component2(){}[0]
+    final fun component3(): kotlin/Double // org.oremif.kstats.descriptive/XBarRChartResult.component3|component3(){}[0]
+    final fun component4(): org.oremif.kstats.descriptive/ControlChartLimits // org.oremif.kstats.descriptive/XBarRChartResult.component4|component4(){}[0]
+    final fun copy(kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., org.oremif.kstats.descriptive/ControlChartLimits = ...): org.oremif.kstats.descriptive/XBarRChartResult // org.oremif.kstats.descriptive/XBarRChartResult.copy|copy(kotlin.Double;kotlin.Double;kotlin.Double;org.oremif.kstats.descriptive.ControlChartLimits){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // org.oremif.kstats.descriptive/XBarRChartResult.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // org.oremif.kstats.descriptive/XBarRChartResult.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // org.oremif.kstats.descriptive/XBarRChartResult.toString|toString(){}[0]
+}
+
+final class org.oremif.kstats.descriptive/XBarSChartResult { // org.oremif.kstats.descriptive/XBarSChartResult|null[0]
+    constructor <init>(kotlin/Double, kotlin/Double, kotlin/Double, org.oremif.kstats.descriptive/ControlChartLimits) // org.oremif.kstats.descriptive/XBarSChartResult.<init>|<init>(kotlin.Double;kotlin.Double;kotlin.Double;org.oremif.kstats.descriptive.ControlChartLimits){}[0]
+
+    final val centerLine // org.oremif.kstats.descriptive/XBarSChartResult.centerLine|{}centerLine[0]
+        final fun <get-centerLine>(): kotlin/Double // org.oremif.kstats.descriptive/XBarSChartResult.centerLine.<get-centerLine>|<get-centerLine>(){}[0]
+    final val lcl // org.oremif.kstats.descriptive/XBarSChartResult.lcl|{}lcl[0]
+        final fun <get-lcl>(): kotlin/Double // org.oremif.kstats.descriptive/XBarSChartResult.lcl.<get-lcl>|<get-lcl>(){}[0]
+    final val sChart // org.oremif.kstats.descriptive/XBarSChartResult.sChart|{}sChart[0]
+        final fun <get-sChart>(): org.oremif.kstats.descriptive/ControlChartLimits // org.oremif.kstats.descriptive/XBarSChartResult.sChart.<get-sChart>|<get-sChart>(){}[0]
+    final val ucl // org.oremif.kstats.descriptive/XBarSChartResult.ucl|{}ucl[0]
+        final fun <get-ucl>(): kotlin/Double // org.oremif.kstats.descriptive/XBarSChartResult.ucl.<get-ucl>|<get-ucl>(){}[0]
+
+    final fun component1(): kotlin/Double // org.oremif.kstats.descriptive/XBarSChartResult.component1|component1(){}[0]
+    final fun component2(): kotlin/Double // org.oremif.kstats.descriptive/XBarSChartResult.component2|component2(){}[0]
+    final fun component3(): kotlin/Double // org.oremif.kstats.descriptive/XBarSChartResult.component3|component3(){}[0]
+    final fun component4(): org.oremif.kstats.descriptive/ControlChartLimits // org.oremif.kstats.descriptive/XBarSChartResult.component4|component4(){}[0]
+    final fun copy(kotlin/Double = ..., kotlin/Double = ..., kotlin/Double = ..., org.oremif.kstats.descriptive/ControlChartLimits = ...): org.oremif.kstats.descriptive/XBarSChartResult // org.oremif.kstats.descriptive/XBarSChartResult.copy|copy(kotlin.Double;kotlin.Double;kotlin.Double;org.oremif.kstats.descriptive.ControlChartLimits){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // org.oremif.kstats.descriptive/XBarSChartResult.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // org.oremif.kstats.descriptive/XBarSChartResult.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // org.oremif.kstats.descriptive/XBarSChartResult.toString|toString(){}[0]
 }
 
 open class org.oremif.kstats.core.exceptions/KStatsException : kotlin/RuntimeException { // org.oremif.kstats.core.exceptions/KStatsException|null[0]
@@ -375,3 +469,6 @@ final fun org.oremif.kstats.core/regularizedGammaP(kotlin/Double, kotlin/Double)
 final fun org.oremif.kstats.core/regularizedGammaQ(kotlin/Double, kotlin/Double): kotlin/Double // org.oremif.kstats.core/regularizedGammaQ|regularizedGammaQ(kotlin.Double;kotlin.Double){}[0]
 final fun org.oremif.kstats.core/secureRandom(): kotlin.random/Random // org.oremif.kstats.core/secureRandom|secureRandom(){}[0]
 final fun org.oremif.kstats.core/trigamma(kotlin/Double): kotlin/Double // org.oremif.kstats.core/trigamma|trigamma(kotlin.Double){}[0]
+final fun org.oremif.kstats.descriptive/spcConstants(kotlin/Int): org.oremif.kstats.descriptive/SpcConstants // org.oremif.kstats.descriptive/spcConstants|spcConstants(kotlin.Int){}[0]
+final fun org.oremif.kstats.descriptive/xBarRChart(kotlin.collections/List<kotlin/DoubleArray>): org.oremif.kstats.descriptive/XBarRChartResult // org.oremif.kstats.descriptive/xBarRChart|xBarRChart(kotlin.collections.List<kotlin.DoubleArray>){}[0]
+final fun org.oremif.kstats.descriptive/xBarSChart(kotlin.collections/List<kotlin/DoubleArray>): org.oremif.kstats.descriptive/XBarSChartResult // org.oremif.kstats.descriptive/xBarSChart|xBarSChart(kotlin.collections.List<kotlin.DoubleArray>){}[0]

--- a/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/ControlChart.kt
+++ b/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/ControlChart.kt
@@ -1,0 +1,302 @@
+package org.oremif.kstats.descriptive
+
+import org.oremif.kstats.core.exceptions.InsufficientDataException
+import org.oremif.kstats.core.exceptions.InvalidParameterException
+
+// ── SPC Constants ──────────────────────────────────────────────────────────────
+
+/**
+ * Standard Statistical Process Control (SPC) constants for a given subgroup size.
+ *
+ * These constants are used to compute control limits for x-bar, R, and S control charts.
+ * They are derived from the sampling distribution of the range and standard deviation
+ * of normally distributed data. Values are tabulated for subgroup sizes 2 through 25.
+ *
+ * ### Example:
+ * ```kotlin
+ * val c = spcConstants(5)
+ * c.a2  // 0.577 — used for x̄-R chart limits
+ * c.a3  // 1.427 — used for x̄-S chart limits
+ * c.c4  // 0.9400 — bias-correction factor for sample standard deviation
+ * ```
+ *
+ * @property a2 factor for computing x-bar chart control limits from the mean range (R-bar).
+ * @property a3 factor for computing x-bar chart control limits from the mean standard deviation (S-bar).
+ * @property d3 factor for computing the lower control limit of the R chart. Zero for small subgroup sizes.
+ * @property d4 factor for computing the upper control limit of the R chart.
+ * @property b3 factor for computing the lower control limit of the S chart. Zero for small subgroup sizes.
+ * @property b4 factor for computing the upper control limit of the S chart.
+ * @property c4 bias-correction factor that relates the expected sample standard deviation to the
+ * population standard deviation for normally distributed data.
+ * @see spcConstants
+ * @see xBarRChart
+ * @see xBarSChart
+ */
+public data class SpcConstants(
+    val a2: Double,
+    val a3: Double,
+    val d3: Double,
+    val d4: Double,
+    val b3: Double,
+    val b4: Double,
+    val c4: Double,
+) {
+    internal companion object {
+        // Standard SPC constants for subgroup sizes n = 2..25.
+        // Source: Montgomery "Introduction to Statistical Quality Control" (7th ed.), Appendix VI;
+        //         NIST/SEMATECH e-Handbook of Statistical Methods, Table 6.3.2.
+        //               A₂      A₃      D₃      D₄      B₃      B₄      c₄
+        val TABLE: Array<SpcConstants> = arrayOf(
+            SpcConstants(1.880, 2.659, 0.000, 3.267, 0.000, 3.267, 0.7979), // n=2
+            SpcConstants(1.023, 1.954, 0.000, 2.574, 0.000, 2.568, 0.8862), // n=3
+            SpcConstants(0.729, 1.628, 0.000, 2.282, 0.000, 2.266, 0.9213), // n=4
+            SpcConstants(0.577, 1.427, 0.000, 2.114, 0.000, 2.089, 0.9400), // n=5
+            SpcConstants(0.483, 1.287, 0.000, 2.004, 0.030, 1.970, 0.9515), // n=6
+            SpcConstants(0.419, 1.182, 0.076, 1.924, 0.118, 1.882, 0.9594), // n=7
+            SpcConstants(0.373, 1.099, 0.136, 1.864, 0.185, 1.815, 0.9650), // n=8
+            SpcConstants(0.337, 1.032, 0.184, 1.816, 0.239, 1.761, 0.9693), // n=9
+            SpcConstants(0.308, 0.975, 0.223, 1.777, 0.284, 1.716, 0.9727), // n=10
+            SpcConstants(0.285, 0.927, 0.256, 1.744, 0.321, 1.679, 0.9754), // n=11
+            SpcConstants(0.266, 0.886, 0.283, 1.717, 0.354, 1.646, 0.9776), // n=12
+            SpcConstants(0.249, 0.850, 0.307, 1.693, 0.382, 1.618, 0.9794), // n=13
+            SpcConstants(0.235, 0.817, 0.328, 1.672, 0.406, 1.594, 0.9810), // n=14
+            SpcConstants(0.223, 0.789, 0.347, 1.653, 0.428, 1.572, 0.9823), // n=15
+            SpcConstants(0.212, 0.763, 0.363, 1.637, 0.448, 1.552, 0.9835), // n=16
+            SpcConstants(0.203, 0.739, 0.378, 1.622, 0.466, 1.534, 0.9845), // n=17
+            SpcConstants(0.194, 0.718, 0.391, 1.608, 0.482, 1.518, 0.9854), // n=18
+            SpcConstants(0.187, 0.698, 0.403, 1.597, 0.497, 1.503, 0.9862), // n=19
+            SpcConstants(0.180, 0.680, 0.415, 1.585, 0.510, 1.490, 0.9869), // n=20
+            SpcConstants(0.173, 0.663, 0.425, 1.575, 0.523, 1.477, 0.9876), // n=21
+            SpcConstants(0.167, 0.647, 0.434, 1.566, 0.534, 1.466, 0.9882), // n=22
+            SpcConstants(0.162, 0.633, 0.443, 1.557, 0.545, 1.455, 0.9887), // n=23
+            SpcConstants(0.157, 0.619, 0.451, 1.548, 0.555, 1.445, 0.9892), // n=24
+            SpcConstants(0.153, 0.606, 0.459, 1.541, 0.565, 1.435, 0.9896), // n=25
+        )
+    }
+}
+
+/**
+ * Returns the standard SPC constants for the given [subgroupSize].
+ *
+ * The constants are tabulated for subgroup sizes 2 through 25, covering the range used
+ * in practice for Shewhart control charts. They are sourced from Montgomery's
+ * "Introduction to Statistical Quality Control" (7th ed.), Appendix VI.
+ *
+ * ### Example:
+ * ```kotlin
+ * val c = spcConstants(4)
+ * c.a2  // 0.729
+ * c.d4  // 2.282
+ * c.b4  // 2.266
+ * ```
+ *
+ * @param subgroupSize the number of observations in each subgroup (must be in 2..25).
+ * @return the [SpcConstants] for that subgroup size.
+ * @see SpcConstants
+ */
+public fun spcConstants(subgroupSize: Int): SpcConstants {
+    if (subgroupSize !in 2..25) throw InvalidParameterException(
+        "Subgroup size must be in 2..25, got $subgroupSize"
+    )
+    return SpcConstants.TABLE[subgroupSize - 2]
+}
+
+// ── Control chart result types ─────────────────────────────────────────────────
+
+/**
+ * Control limits for a single Shewhart control chart.
+ *
+ * Contains the center line and the upper and lower control limits that define the
+ * expected range of variation for a stable (in-control) process. Points falling outside
+ * [ucl] or [lcl] signal a potential out-of-control condition.
+ *
+ * @property centerLine the process average used as the chart's center line.
+ * @property ucl the upper control limit (typically center line plus three sigma).
+ * @property lcl the lower control limit (typically center line minus three sigma).
+ * @see XBarRChartResult
+ * @see XBarSChartResult
+ */
+public data class ControlChartLimits(
+    val centerLine: Double,
+    val ucl: Double,
+    val lcl: Double,
+)
+
+/**
+ * Results of an x-bar and R (range) control chart analysis.
+ *
+ * The top-level properties ([centerLine], [ucl], [lcl]) describe the x-bar chart,
+ * which monitors the process mean. The nested [rChart] describes the R chart, which
+ * monitors the within-subgroup variability using the range.
+ *
+ * @property centerLine the grand mean (average of subgroup means) — center line of the x-bar chart.
+ * @property ucl the upper control limit of the x-bar chart, computed as grand mean plus A₂ times R-bar.
+ * @property lcl the lower control limit of the x-bar chart, computed as grand mean minus A₂ times R-bar.
+ * @property rChart the control limits for the accompanying R chart.
+ * @see xBarRChart
+ */
+public data class XBarRChartResult(
+    val centerLine: Double,
+    val ucl: Double,
+    val lcl: Double,
+    val rChart: ControlChartLimits,
+)
+
+/**
+ * Results of an x-bar and S (standard deviation) control chart analysis.
+ *
+ * The top-level properties ([centerLine], [ucl], [lcl]) describe the x-bar chart,
+ * which monitors the process mean. The nested [sChart] describes the S chart, which
+ * monitors the within-subgroup variability using the sample standard deviation.
+ *
+ * The S chart is generally preferred over the R chart for subgroup sizes above 10, because
+ * the standard deviation uses all observations while the range uses only the extremes.
+ *
+ * @property centerLine the grand mean (average of subgroup means) — center line of the x-bar chart.
+ * @property ucl the upper control limit of the x-bar chart, computed as grand mean plus A₃ times S-bar.
+ * @property lcl the lower control limit of the x-bar chart, computed as grand mean minus A₃ times S-bar.
+ * @property sChart the control limits for the accompanying S chart.
+ * @see xBarSChart
+ */
+public data class XBarSChartResult(
+    val centerLine: Double,
+    val ucl: Double,
+    val lcl: Double,
+    val sChart: ControlChartLimits,
+)
+
+// ── Chart computation ──────────────────────────────────────────────────────────
+
+/**
+ * Computes x-bar and R control chart limits for the given [subgroups].
+ *
+ * The x-bar chart tracks the process mean over time, while the R chart tracks the
+ * within-subgroup variability using the range (max minus min) of each subgroup.
+ * Control limits are set at three sigma from the center line using standard SPC
+ * constants (A₂, D₃, D₄).
+ *
+ * All subgroups must have the same size (between 2 and 25). For subgroup sizes above
+ * 10, consider using [xBarSChart] instead — the standard deviation is a more efficient
+ * estimator of variability than the range for larger samples.
+ *
+ * NaN values in the data propagate through the computation (IEEE 754 semantics).
+ *
+ * ### Example:
+ * ```kotlin
+ * val subgroups = listOf(
+ *     doubleArrayOf(10.1, 10.3, 9.8),
+ *     doubleArrayOf(10.0, 10.2, 9.9),
+ *     doubleArrayOf(10.1, 10.0, 10.3),
+ * )
+ * val chart = xBarRChart(subgroups)
+ * chart.centerLine  // grand mean (x-double-bar)
+ * chart.ucl         // upper control limit for x-bar chart
+ * chart.lcl         // lower control limit for x-bar chart
+ * chart.rChart.ucl  // upper control limit for R chart
+ * ```
+ *
+ * @param subgroups a list of equal-sized subgroups, each containing at least 2 observations.
+ * At least 2 subgroups are required. Subgroup size must be at most 25.
+ * @return an [XBarRChartResult] containing x-bar and R chart limits.
+ * @see xBarSChart
+ * @see spcConstants
+ */
+public fun xBarRChart(subgroups: List<DoubleArray>): XBarRChartResult {
+    validateSubgroups(subgroups)
+    val n = subgroups[0].size
+    val constants = spcConstants(n)
+
+    val subgroupMeans = DoubleArray(subgroups.size) { subgroups[it].mean() }
+    val xBarBar = subgroupMeans.mean()
+
+    val subgroupRanges = DoubleArray(subgroups.size) { subgroups[it].range() }
+    val rBar = subgroupRanges.mean()
+
+    return XBarRChartResult(
+        centerLine = xBarBar,
+        ucl = xBarBar + constants.a2 * rBar,
+        lcl = xBarBar - constants.a2 * rBar,
+        rChart = ControlChartLimits(
+            centerLine = rBar,
+            ucl = constants.d4 * rBar,
+            lcl = constants.d3 * rBar,
+        ),
+    )
+}
+
+/**
+ * Computes x-bar and S control chart limits for the given [subgroups].
+ *
+ * The x-bar chart tracks the process mean over time, while the S chart tracks the
+ * within-subgroup variability using the sample standard deviation. Control limits are
+ * set at three sigma from the center line using standard SPC constants (A₃, B₃, B₄).
+ *
+ * The S chart is generally preferred over the R chart ([xBarRChart]) for subgroup sizes
+ * above 10, because the standard deviation uses all observations while the range uses
+ * only the two extremes.
+ *
+ * All subgroups must have the same size (between 2 and 25).
+ *
+ * NaN values in the data propagate through the computation (IEEE 754 semantics).
+ *
+ * ### Example:
+ * ```kotlin
+ * val subgroups = listOf(
+ *     doubleArrayOf(10.1, 10.3, 9.8),
+ *     doubleArrayOf(10.0, 10.2, 9.9),
+ *     doubleArrayOf(10.1, 10.0, 10.3),
+ * )
+ * val chart = xBarSChart(subgroups)
+ * chart.centerLine  // grand mean (x-double-bar)
+ * chart.ucl         // upper control limit for x-bar chart
+ * chart.sChart.ucl  // upper control limit for S chart
+ * ```
+ *
+ * @param subgroups a list of equal-sized subgroups, each containing at least 2 observations.
+ * At least 2 subgroups are required. Subgroup size must be at most 25.
+ * @return an [XBarSChartResult] containing x-bar and S chart limits.
+ * @see xBarRChart
+ * @see spcConstants
+ */
+public fun xBarSChart(subgroups: List<DoubleArray>): XBarSChartResult {
+    validateSubgroups(subgroups)
+    val n = subgroups[0].size
+    val constants = spcConstants(n)
+
+    val subgroupMeans = DoubleArray(subgroups.size) { subgroups[it].mean() }
+    val xBarBar = subgroupMeans.mean()
+
+    val subgroupStdDevs = DoubleArray(subgroups.size) { subgroups[it].standardDeviation() }
+    val sBar = subgroupStdDevs.mean()
+
+    return XBarSChartResult(
+        centerLine = xBarBar,
+        ucl = xBarBar + constants.a3 * sBar,
+        lcl = xBarBar - constants.a3 * sBar,
+        sChart = ControlChartLimits(
+            centerLine = sBar,
+            ucl = constants.b4 * sBar,
+            lcl = constants.b3 * sBar,
+        ),
+    )
+}
+
+// ── Validation ─────────────────────────────────────────────────────────────────
+
+private fun validateSubgroups(subgroups: List<DoubleArray>) {
+    if (subgroups.size < 2) throw InsufficientDataException(
+        "Control chart requires at least 2 subgroups, got ${subgroups.size}"
+    )
+    val n = subgroups[0].size
+    if (n < 2) throw InsufficientDataException(
+        "Subgroup size must be at least 2, got $n"
+    )
+    if (n > 25) throw InvalidParameterException(
+        "Subgroup size must be at most 25 (SPC constants are tabulated for n=2..25), got $n"
+    )
+    for ((i, sg) in subgroups.withIndex()) {
+        if (sg.size != n) throw InvalidParameterException(
+            "All subgroups must have equal size: subgroup 0 has $n elements, but subgroup $i has ${sg.size}"
+        )
+    }
+}

--- a/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/ControlChart.kt
+++ b/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/ControlChart.kt
@@ -140,7 +140,10 @@ public data class XBarRChartResult(
     val ucl: Double,
     val lcl: Double,
     val rChart: ControlChartLimits,
-)
+) {
+    /** The x-bar chart limits as a [ControlChartLimits] instance for uniform handling. */
+    public val xBarChart: ControlChartLimits get() = ControlChartLimits(centerLine, ucl, lcl)
+}
 
 /**
  * Results of an x-bar and S (standard deviation) control chart analysis.
@@ -163,7 +166,10 @@ public data class XBarSChartResult(
     val ucl: Double,
     val lcl: Double,
     val sChart: ControlChartLimits,
-)
+) {
+    /** The x-bar chart limits as a [ControlChartLimits] instance for uniform handling. */
+    public val xBarChart: ControlChartLimits get() = ControlChartLimits(centerLine, ucl, lcl)
+}
 
 // ── Chart computation ──────────────────────────────────────────────────────────
 

--- a/kstats-core/src/commonTest/kotlin/org/oremif/kstats/descriptive/ControlChartTest.kt
+++ b/kstats-core/src/commonTest/kotlin/org/oremif/kstats/descriptive/ControlChartTest.kt
@@ -1,0 +1,947 @@
+package org.oremif.kstats.descriptive
+
+import org.oremif.kstats.core.exceptions.InsufficientDataException
+import org.oremif.kstats.core.exceptions.InvalidParameterException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+internal class ControlChartTest {
+
+    private val tol = 1e-10
+
+    // ===== spcConstants: Basic correctness =====
+
+    @Test
+    fun testSpcConstantsN2() {
+        // Montgomery "Introduction to Statistical Quality Control" (7th ed.), Appendix VI
+        val c = spcConstants(2)
+        assertEquals(1.880, c.a2, 0.0, "A2 for n=2")
+        assertEquals(2.659, c.a3, 0.0, "A3 for n=2")
+        assertEquals(0.000, c.d3, 0.0, "D3 for n=2")
+        assertEquals(3.267, c.d4, 0.0, "D4 for n=2")
+        assertEquals(0.000, c.b3, 0.0, "B3 for n=2")
+        assertEquals(3.267, c.b4, 0.0, "B4 for n=2")
+        assertEquals(0.7979, c.c4, 0.0, "c4 for n=2")
+    }
+
+    @Test
+    fun testSpcConstantsN5() {
+        // Montgomery Appendix VI, n=5
+        val c = spcConstants(5)
+        assertEquals(0.577, c.a2, 0.0, "A2 for n=5")
+        assertEquals(1.427, c.a3, 0.0, "A3 for n=5")
+        assertEquals(0.000, c.d3, 0.0, "D3 for n=5")
+        assertEquals(2.114, c.d4, 0.0, "D4 for n=5")
+        assertEquals(0.000, c.b3, 0.0, "B3 for n=5")
+        assertEquals(2.089, c.b4, 0.0, "B4 for n=5")
+        assertEquals(0.9400, c.c4, 0.0, "c4 for n=5")
+    }
+
+    @Test
+    fun testSpcConstantsN10() {
+        // Montgomery Appendix VI, n=10
+        val c = spcConstants(10)
+        assertEquals(0.308, c.a2, 0.0, "A2 for n=10")
+        assertEquals(0.975, c.a3, 0.0, "A3 for n=10")
+        assertEquals(0.223, c.d3, 0.0, "D3 for n=10")
+        assertEquals(1.777, c.d4, 0.0, "D4 for n=10")
+        assertEquals(0.284, c.b3, 0.0, "B3 for n=10")
+        assertEquals(1.716, c.b4, 0.0, "B4 for n=10")
+        assertEquals(0.9727, c.c4, 0.0, "c4 for n=10")
+    }
+
+    @Test
+    fun testSpcConstantsN25() {
+        // Montgomery Appendix VI, n=25 (maximum)
+        val c = spcConstants(25)
+        assertEquals(0.153, c.a2, 0.0, "A2 for n=25")
+        assertEquals(0.606, c.a3, 0.0, "A3 for n=25")
+        assertEquals(0.459, c.d3, 0.0, "D3 for n=25")
+        assertEquals(1.541, c.d4, 0.0, "D4 for n=25")
+        assertEquals(0.565, c.b3, 0.0, "B3 for n=25")
+        assertEquals(1.435, c.b4, 0.0, "B4 for n=25")
+        assertEquals(0.9896, c.c4, 0.0, "c4 for n=25")
+    }
+
+    // ===== spcConstants: Edge cases =====
+
+    @Test
+    fun testSpcConstantsBoundaryN2() {
+        // n=2 is the minimum valid subgroup size
+        val c = spcConstants(2)
+        assertTrue(c.a2 > 0.0, "A2 should be positive for n=2")
+        assertTrue(c.d4 > 0.0, "D4 should be positive for n=2")
+    }
+
+    @Test
+    fun testSpcConstantsBoundaryN25() {
+        // n=25 is the maximum valid subgroup size
+        val c = spcConstants(25)
+        assertTrue(c.a2 > 0.0, "A2 should be positive for n=25")
+        assertTrue(c.c4 < 1.0, "c4 should be < 1 for n=25")
+    }
+
+    // ===== spcConstants: Degenerate input =====
+
+    @Test
+    fun testSpcConstantsN0() {
+        assertFailsWith<InvalidParameterException> {
+            spcConstants(0)
+        }
+    }
+
+    @Test
+    fun testSpcConstantsN1() {
+        assertFailsWith<InvalidParameterException> {
+            spcConstants(1)
+        }
+    }
+
+    @Test
+    fun testSpcConstantsN26() {
+        assertFailsWith<InvalidParameterException> {
+            spcConstants(26)
+        }
+    }
+
+    @Test
+    fun testSpcConstantsNegative() {
+        assertFailsWith<InvalidParameterException> {
+            spcConstants(-1)
+        }
+    }
+
+    @Test
+    fun testSpcConstantsLargeN() {
+        assertFailsWith<InvalidParameterException> {
+            spcConstants(100)
+        }
+    }
+
+    // ===== spcConstants: Property-based =====
+
+    @Test
+    fun testSpcConstantsA2Decreasing() {
+        // A2 should decrease as n increases (more data = tighter control limits)
+        for (n in 2..24) {
+            val current = spcConstants(n)
+            val next = spcConstants(n + 1)
+            assertTrue(
+                current.a2 >= next.a2,
+                "A2 should decrease: A2($n)=${current.a2} >= A2(${n + 1})=${next.a2}"
+            )
+        }
+    }
+
+    @Test
+    fun testSpcConstantsC4Increasing() {
+        // c4 should increase toward 1 as n increases
+        for (n in 2..24) {
+            val current = spcConstants(n)
+            val next = spcConstants(n + 1)
+            assertTrue(
+                current.c4 <= next.c4,
+                "c4 should increase: c4($n)=${current.c4} <= c4(${n + 1})=${next.c4}"
+            )
+        }
+    }
+
+    @Test
+    fun testSpcConstantsD4Decreasing() {
+        // D4 should decrease as n increases
+        for (n in 2..24) {
+            val current = spcConstants(n)
+            val next = spcConstants(n + 1)
+            assertTrue(
+                current.d4 >= next.d4,
+                "D4 should decrease: D4($n)=${current.d4} >= D4(${n + 1})=${next.d4}"
+            )
+        }
+    }
+
+    @Test
+    fun testSpcConstantsD3NonNegative() {
+        // D3 should be non-negative for all n
+        for (n in 2..25) {
+            val c = spcConstants(n)
+            assertTrue(c.d3 >= 0.0, "D3 should be non-negative for n=$n")
+        }
+    }
+
+    @Test
+    fun testSpcConstantsB3NonNegative() {
+        // B3 should be non-negative for all n
+        for (n in 2..25) {
+            val c = spcConstants(n)
+            assertTrue(c.b3 >= 0.0, "B3 should be non-negative for n=$n")
+        }
+    }
+
+    @Test
+    fun testSpcConstantsC4LessThanOne() {
+        // c4 should be strictly less than 1 for all finite n
+        for (n in 2..25) {
+            val c = spcConstants(n)
+            assertTrue(c.c4 < 1.0, "c4 should be < 1 for n=$n, got ${c.c4}")
+        }
+    }
+
+    @Test
+    fun testSpcConstantsDataClassEquality() {
+        val c1 = spcConstants(5)
+        val c2 = spcConstants(5)
+        assertEquals(c1, c2, "Same subgroup size should produce equal SpcConstants")
+    }
+
+    // ===== xBarRChart: Basic correctness =====
+
+    @Test
+    fun testXBarRChartKnownValues() {
+        // numpy: 5 subgroups of size 4
+        val subgroups = listOf(
+            doubleArrayOf(72.0, 84.0, 79.0, 49.0),
+            doubleArrayOf(56.0, 87.0, 33.0, 42.0),
+            doubleArrayOf(55.0, 73.0, 22.0, 60.0),
+            doubleArrayOf(44.0, 80.0, 54.0, 74.0),
+            doubleArrayOf(97.0, 26.0, 48.0, 58.0),
+        )
+        val result = xBarRChart(subgroups)
+
+        // numpy: xbar_bar = mean([71, 54.5, 52.5, 63, 57.25]) = 59.65
+        assertEquals(59.65, result.centerLine, tol, "centerLine")
+        // numpy: ucl = 59.65 + 0.729 * 49.4 = 95.6626
+        assertEquals(95.6626, result.ucl, tol, "ucl")
+        // numpy: lcl = 59.65 - 0.729 * 49.4 = 23.6374
+        assertEquals(23.6374, result.lcl, tol, "lcl")
+
+        // R-chart
+        // numpy: r_bar = mean([35, 54, 51, 36, 71]) = 49.4
+        assertEquals(49.4, result.rChart.centerLine, tol, "R-chart centerLine")
+        // numpy: D4 * r_bar = 2.282 * 49.4 = 112.7308
+        assertEquals(112.7308, result.rChart.ucl, tol, "R-chart ucl")
+        // numpy: D3 * r_bar = 0.0 * 49.4 = 0
+        assertEquals(0.0, result.rChart.lcl, tol, "R-chart lcl")
+    }
+
+    @Test
+    fun testXBarRChartSimpleValues() {
+        // numpy: 3 subgroups of size 5
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 12.0, 11.0, 13.0, 9.0),
+            doubleArrayOf(11.0, 10.0, 12.0, 11.0, 14.0),
+            doubleArrayOf(9.0, 13.0, 10.0, 12.0, 11.0),
+        )
+        val result = xBarRChart(subgroups)
+
+        // numpy: xbar_bar = mean([11.0, 11.6, 11.0]) = 11.2
+        assertEquals(11.2, result.centerLine, tol, "centerLine")
+        // numpy: ucl = 11.2 + 0.577 * 4.0 = 13.508
+        assertEquals(13.508, result.ucl, tol, "ucl")
+        // numpy: lcl = 11.2 - 0.577 * 4.0 = 8.892
+        assertEquals(8.892, result.lcl, tol, "lcl")
+
+        // R-chart: r_bar = mean([4, 4, 4]) = 4
+        assertEquals(4.0, result.rChart.centerLine, tol, "R-chart centerLine")
+        // numpy: D4 * 4 = 2.114 * 4 = 8.456
+        assertEquals(8.456, result.rChart.ucl, tol, "R-chart ucl")
+        assertEquals(0.0, result.rChart.lcl, tol, "R-chart lcl")
+    }
+
+    // ===== xBarRChart: Edge cases =====
+
+    @Test
+    fun testXBarRChartMinimumSubgroups() {
+        // Minimum: 2 subgroups
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 20.0),
+            doubleArrayOf(15.0, 25.0),
+        )
+        val result = xBarRChart(subgroups)
+        assertTrue(result.centerLine.isFinite(), "centerLine should be finite")
+        assertTrue(result.ucl.isFinite(), "ucl should be finite")
+        assertTrue(result.lcl.isFinite(), "lcl should be finite")
+    }
+
+    @Test
+    fun testXBarRChartMinimumSubgroupSize() {
+        // Minimum subgroup size: n=2
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 20.0),
+            doubleArrayOf(15.0, 25.0),
+            doubleArrayOf(12.0, 18.0),
+        )
+        val result = xBarRChart(subgroups)
+
+        // numpy: means=[15, 20, 15], xbar_bar=16.667
+        assertEquals(50.0 / 3.0, result.centerLine, tol, "centerLine")
+        // numpy: ranges=[10, 10, 6], r_bar=8.667
+        assertEquals(26.0 / 3.0, result.rChart.centerLine, tol, "R-chart centerLine")
+        // numpy: ucl = 16.667 + 1.880 * 8.667 = 32.96
+        assertEquals(50.0 / 3.0 + 1.880 * 26.0 / 3.0, result.ucl, tol, "ucl")
+    }
+
+    @Test
+    fun testXBarRChartMaxSubgroupSize() {
+        // Maximum subgroup size: n=25
+        // Use reproducible data
+        val subgroups = listOf(
+            DoubleArray(25) { 100.0 + it.toDouble() },
+            DoubleArray(25) { 105.0 + it.toDouble() },
+        )
+        val result = xBarRChart(subgroups)
+        assertTrue(result.centerLine.isFinite(), "centerLine should be finite for n=25")
+        assertTrue(result.ucl > result.centerLine, "ucl > centerLine")
+        assertTrue(result.lcl < result.centerLine, "lcl < centerLine")
+    }
+
+    @Test
+    fun testXBarRChartConstantSubgroups() {
+        // All subgroups have the same values => range = 0, std = 0
+        val subgroups = listOf(
+            doubleArrayOf(5.0, 5.0, 5.0),
+            doubleArrayOf(5.0, 5.0, 5.0),
+        )
+        val result = xBarRChart(subgroups)
+
+        assertEquals(5.0, result.centerLine, tol, "centerLine")
+        // r_bar = 0, so ucl = lcl = centerLine
+        assertEquals(5.0, result.ucl, tol, "ucl = centerLine when all constant")
+        assertEquals(5.0, result.lcl, tol, "lcl = centerLine when all constant")
+        assertEquals(0.0, result.rChart.centerLine, tol, "R-chart centerLine = 0")
+        assertEquals(0.0, result.rChart.ucl, tol, "R-chart ucl = 0")
+        assertEquals(0.0, result.rChart.lcl, tol, "R-chart lcl = 0")
+    }
+
+    // ===== xBarRChart: Degenerate input =====
+
+    @Test
+    fun testXBarRChartEmptyList() {
+        assertFailsWith<InsufficientDataException> {
+            xBarRChart(emptyList())
+        }
+    }
+
+    @Test
+    fun testXBarRChartSingleSubgroup() {
+        assertFailsWith<InsufficientDataException> {
+            xBarRChart(listOf(doubleArrayOf(1.0, 2.0, 3.0)))
+        }
+    }
+
+    @Test
+    fun testXBarRChartSubgroupSizeOne() {
+        assertFailsWith<InsufficientDataException> {
+            xBarRChart(listOf(doubleArrayOf(1.0), doubleArrayOf(2.0)))
+        }
+    }
+
+    @Test
+    fun testXBarRChartSubgroupSizeTooLarge() {
+        assertFailsWith<InvalidParameterException> {
+            xBarRChart(listOf(DoubleArray(26) { it.toDouble() }, DoubleArray(26) { it.toDouble() }))
+        }
+    }
+
+    @Test
+    fun testXBarRChartUnequalSubgroups() {
+        assertFailsWith<InvalidParameterException> {
+            xBarRChart(
+                listOf(
+                    doubleArrayOf(1.0, 2.0, 3.0),
+                    doubleArrayOf(4.0, 5.0),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testXBarRChartUnequalSubgroupsThreeGroups() {
+        assertFailsWith<InvalidParameterException> {
+            xBarRChart(
+                listOf(
+                    doubleArrayOf(1.0, 2.0, 3.0),
+                    doubleArrayOf(4.0, 5.0, 6.0),
+                    doubleArrayOf(7.0, 8.0),
+                )
+            )
+        }
+    }
+
+    // ===== xBarRChart: Extreme parameters =====
+
+    @Test
+    fun testXBarRChartLargeOffsetData() {
+        // Test numerical stability with large offset data
+        val offset = 1e12
+        val subgroups = listOf(
+            doubleArrayOf(offset + 1.0, offset + 2.0, offset + 3.0),
+            doubleArrayOf(offset + 2.0, offset + 3.0, offset + 4.0),
+            doubleArrayOf(offset + 1.5, offset + 2.5, offset + 3.5),
+        )
+        val result = xBarRChart(subgroups)
+
+        // numpy: xbar_bar = 1e12 + 2.5
+        assertEquals(offset + 2.5, result.centerLine, 1e-2, "centerLine with large offset")
+        // numpy: r_bar = 2.0
+        assertEquals(2.0, result.rChart.centerLine, tol, "R-chart centerLine with large offset")
+        assertTrue(result.ucl.isFinite(), "ucl should be finite with large offset")
+        assertTrue(result.lcl.isFinite(), "lcl should be finite with large offset")
+    }
+
+    @Test
+    fun testXBarRChartLargeValues() {
+        // Very large measurement values
+        val subgroups = listOf(
+            doubleArrayOf(1e10, 1.1e10, 0.9e10),
+            doubleArrayOf(1.05e10, 0.95e10, 1.0e10),
+        )
+        val result = xBarRChart(subgroups)
+        assertTrue(result.centerLine.isFinite(), "centerLine should be finite for large values")
+        assertTrue(result.ucl > result.lcl, "ucl > lcl for large values")
+        assertTrue(result.rChart.centerLine > 0.0, "R-chart centerLine > 0")
+    }
+
+    @Test
+    fun testXBarRChartVerySmallValues() {
+        // Very small measurement values
+        val subgroups = listOf(
+            doubleArrayOf(1e-10, 2e-10, 3e-10),
+            doubleArrayOf(1.5e-10, 2.5e-10, 3.5e-10),
+        )
+        val result = xBarRChart(subgroups)
+        assertTrue(result.centerLine.isFinite(), "centerLine should be finite for small values")
+        assertTrue(result.ucl > result.lcl, "ucl > lcl for small values")
+    }
+
+    @Test
+    fun testXBarRChartManySubgroups() {
+        // Many subgroups (stress test for mean computation)
+        val subgroups = List(100) { doubleArrayOf(10.0 + it * 0.01, 11.0 + it * 0.01, 12.0 + it * 0.01) }
+        val result = xBarRChart(subgroups)
+        assertTrue(result.centerLine.isFinite(), "centerLine should be finite for many subgroups")
+        assertTrue(result.rChart.centerLine > 0.0, "R-chart centerLine > 0 for many subgroups")
+    }
+
+    // ===== xBarRChart: Non-finite input =====
+
+    @Test
+    fun testXBarRChartNaNInData() {
+        // NaN in data should propagate through mean and range
+        val subgroups = listOf(
+            doubleArrayOf(1.0, Double.NaN, 3.0),
+            doubleArrayOf(4.0, 5.0, 6.0),
+        )
+        val result = xBarRChart(subgroups)
+        assertTrue(result.centerLine.isNaN(), "centerLine should be NaN when data contains NaN")
+        assertTrue(result.ucl.isNaN(), "ucl should be NaN when data contains NaN")
+    }
+
+    @Test
+    fun testXBarRChartInfinityInData() {
+        // Infinity in data
+        val subgroups = listOf(
+            doubleArrayOf(1.0, Double.POSITIVE_INFINITY, 3.0),
+            doubleArrayOf(4.0, 5.0, 6.0),
+        )
+        val result = xBarRChart(subgroups)
+        // mean with infinity -> infinity, range with infinity -> infinity
+        // Various NaN/Infinity propagation patterns are acceptable
+        assertTrue(
+            !result.centerLine.isFinite() || result.centerLine.isNaN(),
+            "centerLine should be non-finite when data contains Infinity"
+        )
+    }
+
+    @Test
+    fun testXBarRChartNegativeInfinityInData() {
+        val subgroups = listOf(
+            doubleArrayOf(Double.NEGATIVE_INFINITY, 5.0, 6.0),
+            doubleArrayOf(4.0, 5.0, 6.0),
+        )
+        val result = xBarRChart(subgroups)
+        assertTrue(
+            !result.centerLine.isFinite() || result.centerLine.isNaN(),
+            "centerLine should be non-finite when data contains -Infinity"
+        )
+    }
+
+    // ===== xBarRChart: Property-based =====
+
+    @Test
+    fun testXBarRChartUclGtLcl() {
+        // UCL should always be >= LCL (equals when r_bar = 0)
+        val datasets = listOf(
+            listOf(doubleArrayOf(1.0, 2.0, 3.0), doubleArrayOf(2.0, 3.0, 4.0)),
+            listOf(doubleArrayOf(10.0, 20.0), doubleArrayOf(15.0, 25.0)),
+            listOf(
+                doubleArrayOf(100.0, 101.0, 102.0, 103.0, 104.0),
+                doubleArrayOf(99.0, 100.0, 101.0, 102.0, 103.0),
+                doubleArrayOf(100.5, 101.5, 102.5, 103.5, 104.5),
+            ),
+        )
+        for ((i, subgroups) in datasets.withIndex()) {
+            val result = xBarRChart(subgroups)
+            assertTrue(result.ucl >= result.lcl, "ucl >= lcl for dataset $i")
+        }
+    }
+
+    @Test
+    fun testXBarRChartCenterLineBetweenLimits() {
+        // Center line should be between LCL and UCL
+        val subgroups = listOf(
+            doubleArrayOf(72.0, 84.0, 79.0, 49.0),
+            doubleArrayOf(56.0, 87.0, 33.0, 42.0),
+            doubleArrayOf(55.0, 73.0, 22.0, 60.0),
+        )
+        val result = xBarRChart(subgroups)
+        assertTrue(
+            result.centerLine >= result.lcl,
+            "centerLine (${result.centerLine}) >= lcl (${result.lcl})"
+        )
+        assertTrue(
+            result.centerLine <= result.ucl,
+            "centerLine (${result.centerLine}) <= ucl (${result.ucl})"
+        )
+    }
+
+    @Test
+    fun testXBarRChartSymmetricLimits() {
+        // UCL - centerLine should equal centerLine - LCL
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 12.0, 11.0, 13.0, 9.0),
+            doubleArrayOf(11.0, 10.0, 12.0, 11.0, 14.0),
+        )
+        val result = xBarRChart(subgroups)
+        val upperSpread = result.ucl - result.centerLine
+        val lowerSpread = result.centerLine - result.lcl
+        assertEquals(upperSpread, lowerSpread, tol, "X-bar limits should be symmetric")
+    }
+
+    @Test
+    fun testXBarRChartRChartLclNonNegative() {
+        // R-chart LCL should be non-negative (ranges are non-negative)
+        val subgroups = listOf(
+            doubleArrayOf(1.0, 100.0, 50.0),
+            doubleArrayOf(10.0, 90.0, 45.0),
+        )
+        val result = xBarRChart(subgroups)
+        assertTrue(
+            result.rChart.lcl >= 0.0,
+            "R-chart lcl should be non-negative, got ${result.rChart.lcl}"
+        )
+    }
+
+    @Test
+    fun testXBarRChartRChartCenterLineNonNegative() {
+        // R-chart center line (mean of ranges) should be non-negative
+        val subgroups = listOf(
+            doubleArrayOf(1.0, 2.0, 3.0),
+            doubleArrayOf(4.0, 5.0, 6.0),
+            doubleArrayOf(7.0, 8.0, 9.0),
+        )
+        val result = xBarRChart(subgroups)
+        assertTrue(
+            result.rChart.centerLine >= 0.0,
+            "R-chart centerLine should be non-negative"
+        )
+    }
+
+    @Test
+    fun testXBarRChartScaleInvariance() {
+        // Multiplying all data by a constant c should scale limits by c
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 12.0, 11.0),
+            doubleArrayOf(11.0, 10.0, 13.0),
+        )
+        val scaled = subgroups.map { sg -> DoubleArray(sg.size) { sg[it] * 3.0 } }
+
+        val result1 = xBarRChart(subgroups)
+        val result2 = xBarRChart(scaled)
+
+        assertEquals(result1.centerLine * 3.0, result2.centerLine, tol, "centerLine scales linearly")
+        assertEquals(result1.ucl * 3.0, result2.ucl, tol, "ucl scales linearly")
+        assertEquals(result1.lcl * 3.0, result2.lcl, tol, "lcl scales linearly")
+        assertEquals(result1.rChart.centerLine * 3.0, result2.rChart.centerLine, tol, "R-chart centerLine scales linearly")
+    }
+
+    @Test
+    fun testXBarRChartTranslationInvariance() {
+        // Shifting all data by constant c: centerLine shifts by c, rChart unchanged
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 12.0, 11.0),
+            doubleArrayOf(11.0, 10.0, 13.0),
+        )
+        val c = 1000.0
+        val shifted = subgroups.map { sg -> DoubleArray(sg.size) { sg[it] + c } }
+
+        val result1 = xBarRChart(subgroups)
+        val result2 = xBarRChart(shifted)
+
+        assertEquals(result1.centerLine + c, result2.centerLine, tol, "centerLine shifts by c")
+        assertEquals(result1.rChart.centerLine, result2.rChart.centerLine, tol, "R-chart centerLine unchanged by shift")
+        assertEquals(result1.rChart.ucl, result2.rChart.ucl, tol, "R-chart ucl unchanged by shift")
+    }
+
+    @Test
+    fun testXBarRChartDataClassEquality() {
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 12.0, 11.0),
+            doubleArrayOf(11.0, 10.0, 13.0),
+        )
+        val r1 = xBarRChart(subgroups)
+        val r2 = xBarRChart(subgroups)
+        assertEquals(r1, r2, "Same input should produce equal XBarRChartResult")
+    }
+
+    // ===== xBarSChart: Basic correctness =====
+
+    @Test
+    fun testXBarSChartKnownValues() {
+        // numpy: 5 subgroups of size 4
+        val subgroups = listOf(
+            doubleArrayOf(72.0, 84.0, 79.0, 49.0),
+            doubleArrayOf(56.0, 87.0, 33.0, 42.0),
+            doubleArrayOf(55.0, 73.0, 22.0, 60.0),
+            doubleArrayOf(44.0, 80.0, 54.0, 74.0),
+            doubleArrayOf(97.0, 26.0, 48.0, 58.0),
+        )
+        val result = xBarSChart(subgroups)
+
+        // numpy: xbar_bar = 59.65
+        assertEquals(59.65, result.centerLine, tol, "centerLine")
+        // numpy: s_bar = 21.4697313967827
+        assertEquals(21.4697313967827, result.sChart.centerLine, 1e-7, "S-chart centerLine")
+        // numpy: ucl = 59.65 + 1.628 * 21.4697313967827 = 94.6027227139622
+        assertEquals(94.6027227139622, result.ucl, 1e-4, "ucl")
+        // numpy: lcl = 59.65 - 1.628 * 21.4697313967827 = 24.6972772860378
+        assertEquals(24.6972772860378, result.lcl, 1e-4, "lcl")
+        // numpy: B4 * s_bar = 2.266 * 21.4697313967827 = 48.6504113451096
+        assertEquals(48.6504113451096, result.sChart.ucl, 1e-4, "S-chart ucl")
+        // numpy: B3 * s_bar = 0.0 * 21.4697313967827 = 0
+        assertEquals(0.0, result.sChart.lcl, tol, "S-chart lcl")
+    }
+
+    @Test
+    fun testXBarSChartSimpleValues() {
+        // numpy: 3 subgroups of size 5
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 12.0, 11.0, 13.0, 9.0),
+            doubleArrayOf(11.0, 10.0, 12.0, 11.0, 14.0),
+            doubleArrayOf(9.0, 13.0, 10.0, 12.0, 11.0),
+        )
+        val result = xBarSChart(subgroups)
+
+        // numpy: xbar_bar = 11.2
+        assertEquals(11.2, result.centerLine, tol, "centerLine")
+        // numpy: s_bar = 1.5596175829929
+        assertEquals(1.5596175829929, result.sChart.centerLine, 1e-7, "S-chart centerLine")
+        // numpy: ucl = 11.2 + 1.427 * 1.5596175829929 = 13.4255742909309
+        assertEquals(13.4255742909309, result.ucl, 1e-4, "ucl")
+        // numpy: lcl = 11.2 - 1.427 * 1.5596175829929 = 8.97442570906914
+        assertEquals(8.97442570906914, result.lcl, 1e-4, "lcl")
+    }
+
+    // ===== xBarSChart: Edge cases =====
+
+    @Test
+    fun testXBarSChartMinimumSubgroups() {
+        // Minimum: 2 subgroups
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 20.0),
+            doubleArrayOf(15.0, 25.0),
+        )
+        val result = xBarSChart(subgroups)
+        assertTrue(result.centerLine.isFinite(), "centerLine should be finite")
+        assertTrue(result.ucl.isFinite(), "ucl should be finite")
+        assertTrue(result.lcl.isFinite(), "lcl should be finite")
+    }
+
+    @Test
+    fun testXBarSChartMinimumSubgroupSize() {
+        // Minimum subgroup size: n=2
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 20.0),
+            doubleArrayOf(15.0, 25.0),
+            doubleArrayOf(12.0, 18.0),
+        )
+        val result = xBarSChart(subgroups)
+
+        assertEquals(50.0 / 3.0, result.centerLine, tol, "centerLine")
+        assertTrue(result.sChart.centerLine > 0.0, "S-chart centerLine > 0")
+    }
+
+    @Test
+    fun testXBarSChartConstantSubgroups() {
+        // All subgroups have the same values => std = 0
+        val subgroups = listOf(
+            doubleArrayOf(5.0, 5.0, 5.0),
+            doubleArrayOf(5.0, 5.0, 5.0),
+        )
+        val result = xBarSChart(subgroups)
+
+        assertEquals(5.0, result.centerLine, tol, "centerLine")
+        assertEquals(5.0, result.ucl, tol, "ucl = centerLine when all constant")
+        assertEquals(5.0, result.lcl, tol, "lcl = centerLine when all constant")
+        assertEquals(0.0, result.sChart.centerLine, tol, "S-chart centerLine = 0")
+        assertEquals(0.0, result.sChart.ucl, tol, "S-chart ucl = 0")
+        assertEquals(0.0, result.sChart.lcl, tol, "S-chart lcl = 0")
+    }
+
+    // ===== xBarSChart: Degenerate input =====
+
+    @Test
+    fun testXBarSChartEmptyList() {
+        assertFailsWith<InsufficientDataException> {
+            xBarSChart(emptyList())
+        }
+    }
+
+    @Test
+    fun testXBarSChartSingleSubgroup() {
+        assertFailsWith<InsufficientDataException> {
+            xBarSChart(listOf(doubleArrayOf(1.0, 2.0, 3.0)))
+        }
+    }
+
+    @Test
+    fun testXBarSChartSubgroupSizeOne() {
+        assertFailsWith<InsufficientDataException> {
+            xBarSChart(listOf(doubleArrayOf(1.0), doubleArrayOf(2.0)))
+        }
+    }
+
+    @Test
+    fun testXBarSChartSubgroupSizeTooLarge() {
+        assertFailsWith<InvalidParameterException> {
+            xBarSChart(listOf(DoubleArray(26) { it.toDouble() }, DoubleArray(26) { it.toDouble() }))
+        }
+    }
+
+    @Test
+    fun testXBarSChartUnequalSubgroups() {
+        assertFailsWith<InvalidParameterException> {
+            xBarSChart(
+                listOf(
+                    doubleArrayOf(1.0, 2.0, 3.0),
+                    doubleArrayOf(4.0, 5.0),
+                )
+            )
+        }
+    }
+
+    // ===== xBarSChart: Extreme parameters =====
+
+    @Test
+    fun testXBarSChartLargeOffsetData() {
+        val offset = 1e12
+        val subgroups = listOf(
+            doubleArrayOf(offset + 1.0, offset + 2.0, offset + 3.0),
+            doubleArrayOf(offset + 2.0, offset + 3.0, offset + 4.0),
+            doubleArrayOf(offset + 1.5, offset + 2.5, offset + 3.5),
+        )
+        val result = xBarSChart(subgroups)
+
+        assertEquals(offset + 2.5, result.centerLine, 1e-2, "centerLine with large offset")
+        assertTrue(result.sChart.centerLine > 0.0, "S-chart centerLine > 0")
+        assertTrue(result.ucl.isFinite(), "ucl should be finite with large offset")
+        assertTrue(result.lcl.isFinite(), "lcl should be finite with large offset")
+    }
+
+    @Test
+    fun testXBarSChartVerySmallValues() {
+        val subgroups = listOf(
+            doubleArrayOf(1e-10, 2e-10, 3e-10),
+            doubleArrayOf(1.5e-10, 2.5e-10, 3.5e-10),
+        )
+        val result = xBarSChart(subgroups)
+        assertTrue(result.centerLine.isFinite(), "centerLine should be finite for small values")
+        assertTrue(result.ucl > result.lcl, "ucl > lcl for small values")
+    }
+
+    // ===== xBarSChart: Non-finite input =====
+
+    @Test
+    fun testXBarSChartNaNInData() {
+        val subgroups = listOf(
+            doubleArrayOf(1.0, Double.NaN, 3.0),
+            doubleArrayOf(4.0, 5.0, 6.0),
+        )
+        val result = xBarSChart(subgroups)
+        assertTrue(result.centerLine.isNaN(), "centerLine should be NaN when data contains NaN")
+        assertTrue(result.ucl.isNaN(), "ucl should be NaN when data contains NaN")
+    }
+
+    @Test
+    fun testXBarSChartInfinityInData() {
+        val subgroups = listOf(
+            doubleArrayOf(1.0, Double.POSITIVE_INFINITY, 3.0),
+            doubleArrayOf(4.0, 5.0, 6.0),
+        )
+        val result = xBarSChart(subgroups)
+        assertTrue(
+            !result.centerLine.isFinite() || result.centerLine.isNaN(),
+            "centerLine should be non-finite when data contains Infinity"
+        )
+    }
+
+    // ===== xBarSChart: Property-based =====
+
+    @Test
+    fun testXBarSChartUclGtLcl() {
+        val datasets = listOf(
+            listOf(doubleArrayOf(1.0, 2.0, 3.0), doubleArrayOf(2.0, 3.0, 4.0)),
+            listOf(doubleArrayOf(10.0, 20.0), doubleArrayOf(15.0, 25.0)),
+            listOf(
+                doubleArrayOf(100.0, 101.0, 102.0, 103.0, 104.0),
+                doubleArrayOf(99.0, 100.0, 101.0, 102.0, 103.0),
+            ),
+        )
+        for ((i, subgroups) in datasets.withIndex()) {
+            val result = xBarSChart(subgroups)
+            assertTrue(result.ucl >= result.lcl, "ucl >= lcl for dataset $i")
+        }
+    }
+
+    @Test
+    fun testXBarSChartCenterLineBetweenLimits() {
+        val subgroups = listOf(
+            doubleArrayOf(72.0, 84.0, 79.0, 49.0),
+            doubleArrayOf(56.0, 87.0, 33.0, 42.0),
+            doubleArrayOf(55.0, 73.0, 22.0, 60.0),
+        )
+        val result = xBarSChart(subgroups)
+        assertTrue(
+            result.centerLine >= result.lcl,
+            "centerLine (${result.centerLine}) >= lcl (${result.lcl})"
+        )
+        assertTrue(
+            result.centerLine <= result.ucl,
+            "centerLine (${result.centerLine}) <= ucl (${result.ucl})"
+        )
+    }
+
+    @Test
+    fun testXBarSChartSymmetricLimits() {
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 12.0, 11.0, 13.0, 9.0),
+            doubleArrayOf(11.0, 10.0, 12.0, 11.0, 14.0),
+        )
+        val result = xBarSChart(subgroups)
+        val upperSpread = result.ucl - result.centerLine
+        val lowerSpread = result.centerLine - result.lcl
+        assertEquals(upperSpread, lowerSpread, tol, "X-bar limits should be symmetric")
+    }
+
+    @Test
+    fun testXBarSChartSChartLclNonNegative() {
+        val subgroups = listOf(
+            doubleArrayOf(1.0, 100.0, 50.0),
+            doubleArrayOf(10.0, 90.0, 45.0),
+        )
+        val result = xBarSChart(subgroups)
+        assertTrue(
+            result.sChart.lcl >= 0.0,
+            "S-chart lcl should be non-negative, got ${result.sChart.lcl}"
+        )
+    }
+
+    @Test
+    fun testXBarSChartScaleInvariance() {
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 12.0, 11.0),
+            doubleArrayOf(11.0, 10.0, 13.0),
+        )
+        val factor = 5.0
+        val scaled = subgroups.map { sg -> DoubleArray(sg.size) { sg[it] * factor } }
+
+        val result1 = xBarSChart(subgroups)
+        val result2 = xBarSChart(scaled)
+
+        assertEquals(result1.centerLine * factor, result2.centerLine, tol, "centerLine scales linearly")
+        assertEquals(result1.sChart.centerLine * factor, result2.sChart.centerLine, 1e-6, "S-chart centerLine scales linearly")
+    }
+
+    @Test
+    fun testXBarSChartTranslationInvariance() {
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 12.0, 11.0),
+            doubleArrayOf(11.0, 10.0, 13.0),
+        )
+        val c = 500.0
+        val shifted = subgroups.map { sg -> DoubleArray(sg.size) { sg[it] + c } }
+
+        val result1 = xBarSChart(subgroups)
+        val result2 = xBarSChart(shifted)
+
+        assertEquals(result1.centerLine + c, result2.centerLine, tol, "centerLine shifts by c")
+        assertEquals(result1.sChart.centerLine, result2.sChart.centerLine, 1e-6, "S-chart centerLine unchanged by shift")
+    }
+
+    @Test
+    fun testXBarSChartDataClassEquality() {
+        val subgroups = listOf(
+            doubleArrayOf(10.0, 12.0, 11.0),
+            doubleArrayOf(11.0, 10.0, 13.0),
+        )
+        val r1 = xBarSChart(subgroups)
+        val r2 = xBarSChart(subgroups)
+        assertEquals(r1, r2, "Same input should produce equal XBarSChartResult")
+    }
+
+    // ===== Cross-chart consistency =====
+
+    @Test
+    fun testXBarRAndXBarSShareCenterLine() {
+        // Both charts should have the same x-bar center line (grand mean)
+        val subgroups = listOf(
+            doubleArrayOf(72.0, 84.0, 79.0, 49.0),
+            doubleArrayOf(56.0, 87.0, 33.0, 42.0),
+            doubleArrayOf(55.0, 73.0, 22.0, 60.0),
+        )
+        val rResult = xBarRChart(subgroups)
+        val sResult = xBarSChart(subgroups)
+
+        assertEquals(
+            rResult.centerLine,
+            sResult.centerLine,
+            tol,
+            "X-bar center lines should be identical"
+        )
+    }
+
+    @Test
+    fun testControlChartLimitsDataClass() {
+        // Test the ControlChartLimits data class
+        val limits = ControlChartLimits(centerLine = 50.0, ucl = 60.0, lcl = 40.0)
+        assertEquals(50.0, limits.centerLine, 0.0)
+        assertEquals(60.0, limits.ucl, 0.0)
+        assertEquals(40.0, limits.lcl, 0.0)
+
+        // Copy
+        val modified = limits.copy(ucl = 70.0)
+        assertEquals(70.0, modified.ucl, 0.0)
+        assertEquals(50.0, modified.centerLine, 0.0)
+    }
+
+    @Test
+    fun testXBarRChartResultDataClass() {
+        val rChart = ControlChartLimits(centerLine = 5.0, ucl = 10.0, lcl = 0.0)
+        val result = XBarRChartResult(centerLine = 50.0, ucl = 55.0, lcl = 45.0, rChart = rChart)
+        assertEquals(50.0, result.centerLine, 0.0)
+        assertEquals(55.0, result.ucl, 0.0)
+        assertEquals(45.0, result.lcl, 0.0)
+        assertEquals(rChart, result.rChart)
+    }
+
+    @Test
+    fun testXBarSChartResultDataClass() {
+        val sChart = ControlChartLimits(centerLine = 2.0, ucl = 4.0, lcl = 0.0)
+        val result = XBarSChartResult(centerLine = 50.0, ucl = 55.0, lcl = 45.0, sChart = sChart)
+        assertEquals(50.0, result.centerLine, 0.0)
+        assertEquals(55.0, result.ucl, 0.0)
+        assertEquals(45.0, result.lcl, 0.0)
+        assertEquals(sChart, result.sChart)
+    }
+}


### PR DESCRIPTION
## Description

Add SPC constants lookup table (A₂, A₃, D₃, D₄, B₃, B₄, c₄) for subgroup sizes 2–25
and control limit computation for x̄-R and x̄-S charts.

Closes #35

## Testing

`./gradlew :kstats-core:jvmTest`

## Checklist

- [x] Existing tests pass
- [x] New/updated tests for changed behavior
- [x] New/updated documentation if necessary