### PR TITLE
chore: migrate to korro 0.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,14 +38,19 @@ dokka {
 }
 
 korro {
-    docs = fileTree(rootProject.rootDir) {
-        include("README.md")
-        include("kstats-*/Module.md")
-        include("docs/**/*.mdx")
-        include("dokka/modules.md")
+    docs {
+        from(fileTree(rootProject.rootDir) {
+            include("README.md")
+            include("kstats-*/Module.md")
+            include("docs/**/*.mdx")
+            include("dokka/modules.md")
+        })
+        baseDir.set(rootProject.layout.projectDirectory)
     }
 
-    samples = fileTree(project.projectDir) {
-        include("kstats-*/src/commonTest/kotlin/org/oremif/kstats/**/samples/*.kt")
+    samples {
+        from(fileTree(project.projectDir) {
+            include("kstats-*/src/commonTest/kotlin/org/oremif/kstats/**/samples/*.kt")
+        })
     }
 }

--- a/docs/core/overview.mdx
+++ b/docs/core/overview.mdx
@@ -3,8 +3,8 @@ title: "Descriptive Statistics"
 description: "Summary statistics, central tendency, dispersion, quantiles, shape measures, frequency analysis, and streaming calculations in kstats-core."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.sampling.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.sampling.samples.DocsSamples--*/}
 
 `kstats-core` provides descriptive statistics as extension functions on `DoubleArray` and `Iterable<Double>`. It also includes `Int` and `Long` overloads for the most common operations.
 
@@ -12,7 +12,7 @@ description: "Summary statistics, central tendency, dispersion, quantiles, shape
 
 `describe()` is the fastest way to get a complete picture of a sample. It returns a `DescriptiveStatistics` object combining count, center, spread, quartiles, shape, and standard error.
 
-[//]: # (<!---FUN coreSummarySnapshot-->)
+{/*---FUN coreSummarySnapshot--*/}
 
 ```kotlin
 val data = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
@@ -32,7 +32,7 @@ stats.range              // 7.0
 stats.standardError      // 0.7559
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 `variance()` and `standardDeviation()` use the **sample** formula (dividing by $n - 1$) by default. Pass `PopulationKind.POPULATION` to use the population formula (dividing by $n$).
@@ -42,7 +42,7 @@ stats.standardError      // 0.7559
 
 Different notions of "center" suit different data shapes. `mean()` is the arithmetic average, `median()` is the positional center, `mode()` returns the most frequent values, and the trimmed and weighted variants handle outliers and importance weights.
 
-[//]: # (<!---FUN coreCentralTendency-->)
+{/*---FUN coreCentralTendency--*/}
 
 ```kotlin
 val data = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
@@ -62,7 +62,7 @@ val weights = doubleArrayOf(3.0, 1.0, 1.0)
 values.weightedMean(weights)   // 1.6
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 - **Geometric mean** — use for growth rates and ratios. Requires all positive values.
 - **Harmonic mean** — use for rates and speed averages. Requires all positive values.
@@ -93,7 +93,7 @@ The trimmed mean drops $\lfloor p \cdot n \rfloor$ observations from each end of
 
 Spread measures describe how far values deviate from the center.
 
-[//]: # (<!---FUN coreDispersion-->)
+{/*---FUN coreDispersion--*/}
 
 ```kotlin
 val data = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
@@ -111,7 +111,7 @@ data.semiVariance(5.0, SemiVarianceDirection.DOWNSIDE) // 1.7143
 data.semiVariance(5.0, SemiVarianceDirection.UPSIDE)   // 2.8571
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 `semiVariance` measures variability on one side of a threshold. `DOWNSIDE` captures risk below the threshold; `UPSIDE` captures variability above it.
@@ -137,7 +137,7 @@ $$
 
 Quantiles split the data at specified probability thresholds. `percentile()` takes a value on the 0–100 scale; `quantile()` takes a value on the 0–1 scale.
 
-[//]: # (<!---FUN coreQuantiles-->)
+{/*---FUN coreQuantiles--*/}
 
 ```kotlin
 val data = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
@@ -150,7 +150,7 @@ val (q1, median, q3) = data.quartiles()
 // q1 = 3.25, median = 5.5, q3 = 7.75
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 `quantile()` supports a `QuantileInterpolation` parameter with options: `LINEAR` (default), `LOWER`, `HIGHER`, `NEAREST`, and `MIDPOINT`. These control how the value is interpolated when the quantile falls between two data points.
@@ -170,7 +170,7 @@ where $h = p(n - 1) + 1$.
 
 Shape measures describe asymmetry and tail weight beyond what the mean and variance capture.
 
-[//]: # (<!---FUN coreShape-->)
+{/*---FUN coreShape--*/}
 
 ```kotlin
 val data = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
@@ -187,7 +187,7 @@ data.kStatistic(1)          // 5.0 (equals mean)
 data.kStatistic(2)          // 4.5714 (equals sample variance)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Skewness near zero suggests symmetry. Positive skewness indicates a longer right tail; negative indicates a longer left tail. Excess kurtosis near zero is similar to a normal distribution; positive values indicate heavier tails.
 
@@ -211,7 +211,7 @@ The $r$-th central moment is $\mu_r = \frac{1}{n}\sum_{i=1}^{n}(x_i - \bar{x})^r
 
 The `Frequency` class counts occurrences, proportions, and cumulative frequencies for any `Comparable` type. `frequencyTable()` groups numeric data into equal-width bins.
 
-[//]: # (<!---FUN coreFrequency-->)
+{/*---FUN coreFrequency--*/}
 
 ```kotlin
 val freq = listOf("a", "a", "b", "b", "b", "c").toFrequency()
@@ -222,9 +222,9 @@ freq.cumulativeCount("b")  // 5 (a=2 + b=3)
 freq.mode                  // {b}
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
-[//]: # (<!---FUN coreFrequencyTable-->)
+{/*---FUN coreFrequencyTable--*/}
 
 ```kotlin
 val data = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
@@ -234,7 +234,7 @@ bins[0].count              // number of values in the first bin
 bins[0].relativeFrequency  // proportion of total
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 `Frequency` works with any `Comparable` type — strings, enums, integers, or custom classes. For numeric binning, use `frequencyTable()` with either a bin count or a bin width.
@@ -244,7 +244,7 @@ bins[0].relativeFrequency  // proportion of total
 
 `OnlineStatistics` computes mean, variance, skewness, and kurtosis incrementally without storing the full sample. Values can be added one at a time or in batches.
 
-[//]: # (<!---FUN coreStreaming-->)
+{/*---FUN coreStreaming--*/}
 
 ```kotlin
 val online = OnlineStatistics()
@@ -265,7 +265,7 @@ online.count               // 9
 online.mean                // 4.7778
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Use `OnlineStatistics` when data arrives incrementally (streaming, event-driven systems) or when buffering the full sample in memory is impractical.
 

--- a/docs/correlation/overview.mdx
+++ b/docs/correlation/overview.mdx
@@ -3,7 +3,7 @@ title: "Correlation & Regression"
 description: "Pearson, Spearman, Kendall tau, partial correlation, point-biserial, matrices, covariance, and simple linear regression in kstats-correlation."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.correlation.samples.DocsSamples--*/}
 
 `kstats-correlation` covers two related tasks: measuring the strength of association between variables, and modeling a linear relationship. The module is split into two sections reflecting this distinction.
 
@@ -13,7 +13,7 @@ description: "Pearson, Spearman, Kendall tau, partial correlation, point-biseria
 
 Measures the strength and direction of the **linear** association between two numeric variables. The coefficient ranges from -1 (perfect negative) to +1 (perfect positive).
 
-[//]: # (<!---FUN corrPearson-->)
+{/*---FUN corrPearson--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -25,7 +25,7 @@ r.pValue                 // 0.0001
 r.n                      // 5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Use Pearson when both variables are continuous and the relationship is approximately linear. Sensitive to outliers.
 
@@ -33,7 +33,7 @@ Use Pearson when both variables are continuous and the relationship is approxima
 
 Applies Pearson correlation to the **ranks** of the data. Measures monotonic association — whether the variables tend to increase together, regardless of linearity.
 
-[//]: # (<!---FUN corrSpearman-->)
+{/*---FUN corrSpearman--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0)
@@ -44,7 +44,7 @@ r.coefficient            // 1.0 — perfect monotonic relationship
 r.pValue                 // 0.0
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Use Spearman when the relationship is monotonic but not necessarily linear, or when the data contains outliers.
 
@@ -52,7 +52,7 @@ Use Spearman when the relationship is monotonic but not necessarily linear, or w
 
 Counts concordant and discordant pairs to measure ordinal association. More robust than Spearman for small samples and heavy ties.
 
-[//]: # (<!---FUN corrKendall-->)
+{/*---FUN corrKendall--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -63,7 +63,7 @@ tau.coefficient          // 0.6
 tau.pValue               // p-value for tau
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 The Kendall tau implementation runs in $O(n \log n)$ time using a merge-sort–based algorithm, making it efficient for large datasets.
@@ -73,7 +73,7 @@ The Kendall tau implementation runs in $O(n \log n)$ time using a merge-sort–b
 
 Measures the association between a **binary** variable (coded as 0/1 integers) and a **continuous** variable. Equivalent to Pearson correlation when one variable is dichotomous.
 
-[//]: # (<!---FUN corrPointBiserial-->)
+{/*---FUN corrPointBiserial--*/}
 
 ```kotlin
 val binary     = intArrayOf(0, 0, 0, 1, 1, 1, 1)
@@ -84,7 +84,7 @@ r.coefficient            // positive — group 1 has higher values
 r.pValue                 // p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Use when one variable is naturally binary: treatment/control, pass/fail, male/female.
 
@@ -92,7 +92,7 @@ Use when one variable is naturally binary: treatment/control, pass/fail, male/fe
 
 Measures the association between two variables **after controlling for** a third variable. Removes the effect of the confounding variable.
 
-[//]: # (<!---FUN corrPartial-->)
+{/*---FUN corrPartial--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -104,7 +104,7 @@ r.coefficient            // correlation between x and y, controlling for z
 r.pValue                 // p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Use when a third variable might explain the apparent relationship between the first two.
 
@@ -112,7 +112,7 @@ Use when a third variable might explain the apparent relationship between the fi
 
 For multi-variable analysis, build pairwise matrices. Each cell $(i, j)$ contains the correlation (or covariance) between variables $i$ and $j$.
 
-[//]: # (<!---FUN corrMatrices-->)
+{/*---FUN corrMatrices--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -128,7 +128,7 @@ cov[0][0]                // variance of x = 2.5
 cov[0][1]                // covariance of x and y
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Choosing a Correlation Method
 
@@ -168,7 +168,7 @@ $$
 
 Fits the line $\hat{y} = \beta_0 + \beta_1 x$ to the data using ordinary least squares. The result includes the slope, intercept, goodness-of-fit ($R^2$), standard errors, residuals, and a prediction function.
 
-[//]: # (<!---FUN corrRegression-->)
+{/*---FUN corrRegression--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -188,7 +188,7 @@ model.predict(6.0)           // 11.99
 model.predict(doubleArrayOf(6.0, 7.0, 8.0)) // batch prediction
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Accordion title="Math details">
 $$

--- a/docs/de/core/overview.mdx
+++ b/docs/de/core/overview.mdx
@@ -3,8 +3,8 @@ title: "Deskriptive Statistik"
 description: "Zusammenfassende Statistiken, Lagemaße, Streuungsmaße, Quantile, Formkennzahlen, Häufigkeitsanalyse und Streaming-Berechnungen in kstats-core."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.sampling.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.sampling.samples.DocsSamples--*/}
 
 `kstats-core` stellt deskriptive Statistiken als Erweiterungsfunktionen auf `DoubleArray` und `Iterable<Double>` bereit. Zusätzlich sind `Int`- und `Long`-Überladungen für die gängigsten Operationen verfügbar.
 
@@ -12,7 +12,7 @@ description: "Zusammenfassende Statistiken, Lagemaße, Streuungsmaße, Quantile,
 
 `describe()` ist der schnellste Weg, ein vollständiges Bild einer Stichprobe zu erhalten. Die Methode gibt ein `DescriptiveStatistics`-Objekt zurück, das Anzahl, Lagemaße, Streuung, Quartile, Formkennzahlen und Standardfehler kombiniert.
 
-[//]: # (<!---FUN coreSummarySnapshot-->)
+{/*---FUN coreSummarySnapshot--*/}
 
 ```kotlin
 val data = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
@@ -32,7 +32,7 @@ stats.range              // 7.0
 stats.standardError      // 0.7559
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 `variance()` und `standardDeviation()` verwenden standardmäßig die **Stichprobenformel** (Division durch $n - 1$). Übergeben Sie `PopulationKind.POPULATION`, um die Populationsformel (Division durch $n$) zu verwenden.
@@ -42,7 +42,7 @@ stats.standardError      // 0.7559
 
 Verschiedene Begriffe von „Mitte" passen zu verschiedenen Datenformen. `mean()` ist das arithmetische Mittel, `median()` ist der Positionsmittelwert, `mode()` gibt die häufigsten Werte zurück, und die getrimmten sowie gewichteten Varianten behandeln Ausreißer und Gewichtungen.
 
-[//]: # (<!---FUN coreCentralTendency-->)
+{/*---FUN coreCentralTendency--*/}
 
 ```kotlin
 val data = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
@@ -62,7 +62,7 @@ val weights = doubleArrayOf(3.0, 1.0, 1.0)
 values.weightedMean(weights)   // 1.6
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 - **Geometrisches Mittel** — geeignet für Wachstumsraten und Verhältnisse. Erfordert ausschließlich positive Werte.
 - **Harmonisches Mittel** — geeignet für Raten und Geschwindigkeitsdurchschnitte. Erfordert ausschließlich positive Werte.
@@ -93,7 +93,7 @@ Das getrimmte Mittel entfernt $\lfloor p \cdot n \rfloor$ Beobachtungen von jede
 
 Streuungsmaße beschreiben, wie weit die Werte vom Zentrum abweichen.
 
-[//]: # (<!---FUN coreDispersion-->)
+{/*---FUN coreDispersion--*/}
 
 ```kotlin
 val data = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
@@ -111,7 +111,7 @@ data.semiVariance(5.0, SemiVarianceDirection.DOWNSIDE) // 1.7143
 data.semiVariance(5.0, SemiVarianceDirection.UPSIDE)   // 2.8571
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 `semiVariance` misst die Variabilität auf einer Seite eines Schwellenwerts. `DOWNSIDE` erfasst das Risiko unterhalb des Schwellenwerts; `UPSIDE` erfasst die Variabilität oberhalb davon.
@@ -137,7 +137,7 @@ $$
 
 Quantile teilen die Daten an bestimmten Wahrscheinlichkeitsschwellen. `percentile()` erwartet einen Wert auf der Skala 0–100; `quantile()` erwartet einen Wert auf der Skala 0–1.
 
-[//]: # (<!---FUN coreQuantiles-->)
+{/*---FUN coreQuantiles--*/}
 
 ```kotlin
 val data = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
@@ -150,7 +150,7 @@ val (q1, median, q3) = data.quartiles()
 // q1 = 3.25, median = 5.5, q3 = 7.75
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 `quantile()` unterstützt einen `QuantileInterpolation`-Parameter mit den Optionen: `LINEAR` (Standard), `LOWER`, `HIGHER`, `NEAREST` und `MIDPOINT`. Diese steuern, wie der Wert interpoliert wird, wenn das Quantil zwischen zwei Datenpunkten liegt.
@@ -170,7 +170,7 @@ wobei $h = p(n - 1) + 1$.
 
 Formkennzahlen beschreiben Asymmetrie und Randschwere über Mittelwert und Varianz hinaus.
 
-[//]: # (<!---FUN coreShape-->)
+{/*---FUN coreShape--*/}
 
 ```kotlin
 val data = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
@@ -187,7 +187,7 @@ data.kStatistic(1)          // 5.0 (equals mean)
 data.kStatistic(2)          // 4.5714 (equals sample variance)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Eine Schiefe nahe null deutet auf Symmetrie hin. Positive Schiefe weist auf einen längeren rechten Rand hin; negative auf einen längeren linken Rand. Exzess-Kurtosis nahe null ähnelt einer Normalverteilung; positive Werte deuten auf schwerere Ränder hin.
 
@@ -211,7 +211,7 @@ Das $r$-te zentrale Moment ist $\mu_r = \frac{1}{n}\sum_{i=1}^{n}(x_i - \bar{x})
 
 Die Klasse `Frequency` zählt Vorkommen, Anteile und kumulative Häufigkeiten für beliebige `Comparable`-Typen. `frequencyTable()` gruppiert numerische Daten in gleich breite Klassen.
 
-[//]: # (<!---FUN coreFrequency-->)
+{/*---FUN coreFrequency--*/}
 
 ```kotlin
 val freq = listOf("a", "a", "b", "b", "b", "c").toFrequency()
@@ -222,9 +222,9 @@ freq.cumulativeCount("b")  // 5 (a=2 + b=3)
 freq.mode                  // {b}
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
-[//]: # (<!---FUN coreFrequencyTable-->)
+{/*---FUN coreFrequencyTable--*/}
 
 ```kotlin
 val data = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
@@ -234,7 +234,7 @@ bins[0].count              // number of values in the first bin
 bins[0].relativeFrequency  // proportion of total
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 `Frequency` funktioniert mit jedem `Comparable`-Typ — Strings, Enums, Ganzzahlen oder eigene Klassen. Für numerische Klasseneinteilung verwenden Sie `frequencyTable()` mit einer Klassenanzahl oder einer Klassenbreite.
@@ -244,7 +244,7 @@ bins[0].relativeFrequency  // proportion of total
 
 `OnlineStatistics` berechnet Mittelwert, Varianz, Schiefe und Kurtosis inkrementell, ohne die gesamte Stichprobe zu speichern. Werte können einzeln oder als Stapel hinzugefügt werden.
 
-[//]: # (<!---FUN coreStreaming-->)
+{/*---FUN coreStreaming--*/}
 
 ```kotlin
 val online = OnlineStatistics()
@@ -265,7 +265,7 @@ online.count               // 9
 online.mean                // 4.7778
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Verwenden Sie `OnlineStatistics`, wenn Daten inkrementell eintreffen (Streaming, ereignisgesteuerte Systeme) oder wenn das Speichern der gesamten Stichprobe im Arbeitsspeicher nicht praktikabel ist.
 

--- a/docs/de/correlation/overview.mdx
+++ b/docs/de/correlation/overview.mdx
@@ -3,7 +3,7 @@ title: "Korrelation & Regression"
 description: "Pearson-, Spearman-, Kendall-Tau-, partielle Korrelation, punktbiseriale Korrelation, Matrizen, Kovarianz und einfache lineare Regression in kstats-correlation."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.correlation.samples.DocsSamples--*/}
 
 `kstats-correlation` deckt zwei verwandte Aufgaben ab: die Stärke des Zusammenhangs zwischen Variablen messen und eine lineare Beziehung modellieren. Das Modul ist in zwei Abschnitte unterteilt, die diese Unterscheidung widerspiegeln.
 
@@ -13,7 +13,7 @@ description: "Pearson-, Spearman-, Kendall-Tau-, partielle Korrelation, punktbis
 
 Misst die Stärke und Richtung des **linearen** Zusammenhangs zwischen zwei numerischen Variablen. Der Koeffizient reicht von -1 (perfekt negativ) bis +1 (perfekt positiv).
 
-[//]: # (<!---FUN corrPearson-->)
+{/*---FUN corrPearson--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -25,7 +25,7 @@ r.pValue                 // 0.0001
 r.n                      // 5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Verwenden Sie Pearson, wenn beide Variablen stetig sind und die Beziehung annähernd linear ist. Empfindlich gegenüber Ausreißern.
 
@@ -33,7 +33,7 @@ Verwenden Sie Pearson, wenn beide Variablen stetig sind und die Beziehung annäh
 
 Wendet die Pearson-Korrelation auf die **Ränge** der Daten an. Misst monotone Zusammenhänge — ob die Variablen dazu tendieren, gemeinsam zu steigen, unabhängig von der Linearität.
 
-[//]: # (<!---FUN corrSpearman-->)
+{/*---FUN corrSpearman--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0)
@@ -44,7 +44,7 @@ r.coefficient            // 1.0 — perfect monotonic relationship
 r.pValue                 // 0.0
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Verwenden Sie Spearman, wenn die Beziehung monoton, aber nicht zwingend linear ist, oder wenn die Daten Ausreißer enthalten.
 
@@ -52,7 +52,7 @@ Verwenden Sie Spearman, wenn die Beziehung monoton, aber nicht zwingend linear i
 
 Zählt konkordante und diskordante Paare zur Messung der ordinalen Assoziation. Robuster als Spearman bei kleinen Stichproben und vielen Bindungen.
 
-[//]: # (<!---FUN corrKendall-->)
+{/*---FUN corrKendall--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -63,7 +63,7 @@ tau.coefficient          // 0.6
 tau.pValue               // p-value for tau
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Die Kendall-Tau-Implementierung läuft in $O(n \log n)$ Zeit mithilfe eines Merge-Sort-basierten Algorithmus und ist damit auch für große Datensätze effizient.
@@ -73,7 +73,7 @@ Die Kendall-Tau-Implementierung läuft in $O(n \log n)$ Zeit mithilfe eines Merg
 
 Misst den Zusammenhang zwischen einer **binären** Variable (kodiert als 0/1 Ganzzahlen) und einer **stetigen** Variable. Entspricht der Pearson-Korrelation, wenn eine Variable dichotom ist.
 
-[//]: # (<!---FUN corrPointBiserial-->)
+{/*---FUN corrPointBiserial--*/}
 
 ```kotlin
 val binary     = intArrayOf(0, 0, 0, 1, 1, 1, 1)
@@ -84,7 +84,7 @@ r.coefficient            // positive — group 1 has higher values
 r.pValue                 // p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Geeignet, wenn eine Variable von Natur aus binär ist: Behandlung/Kontrolle, bestanden/nicht bestanden, männlich/weiblich.
 
@@ -92,7 +92,7 @@ Geeignet, wenn eine Variable von Natur aus binär ist: Behandlung/Kontrolle, bes
 
 Misst den Zusammenhang zwischen zwei Variablen **nach Kontrolle** einer dritten Variable. Entfernt den Effekt der Störvariablen.
 
-[//]: # (<!---FUN corrPartial-->)
+{/*---FUN corrPartial--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -104,7 +104,7 @@ r.coefficient            // correlation between x and y, controlling for z
 r.pValue                 // p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Verwenden Sie sie, wenn eine dritte Variable den scheinbaren Zusammenhang zwischen den ersten beiden erklären könnte.
 
@@ -112,7 +112,7 @@ Verwenden Sie sie, wenn eine dritte Variable den scheinbaren Zusammenhang zwisch
 
 Für die Analyse mehrerer Variablen können paarweise Matrizen erstellt werden. Jede Zelle $(i, j)$ enthält die Korrelation (oder Kovarianz) zwischen den Variablen $i$ und $j$.
 
-[//]: # (<!---FUN corrMatrices-->)
+{/*---FUN corrMatrices--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -128,7 +128,7 @@ cov[0][0]                // variance of x = 2.5
 cov[0][1]                // covariance of x and y
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Wahl der Korrelationsmethode
 
@@ -168,7 +168,7 @@ $$
 
 Passt die Gerade $\hat{y} = \beta_0 + \beta_1 x$ mittels gewöhnlicher kleinster Quadrate an die Daten an. Das Ergebnis umfasst Steigung, Achsenabschnitt, Bestimmtheitsmaß ($R^2$), Standardfehler, Residuen und eine Vorhersagefunktion.
 
-[//]: # (<!---FUN corrRegression-->)
+{/*---FUN corrRegression--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -188,7 +188,7 @@ model.predict(6.0)           // 11.99
 model.predict(doubleArrayOf(6.0, 7.0, 8.0)) // batch prediction
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Accordion title="Mathematische Details">
 $$

--- a/docs/de/distributions/overview.mdx
+++ b/docs/de/distributions/overview.mdx
@@ -3,13 +3,13 @@ title: "Wahrscheinlichkeitsverteilungen"
 description: "18 stetige und 10 diskrete Wahrscheinlichkeitsverteilungen mit einheitlicher API für Dichte, CDF, Quantile und Stichprobenziehung in kstats-distributions."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.distributions.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.distributions.samples.DocsSamples--*/}
 
 `kstats-distributions` bietet eine einheitliche API für stetige und diskrete Wahrscheinlichkeitsmodelle. Jede Verteilung unterstützt denselben Arbeitsablauf: Konstruktion mit Parametern, Abfrage statistischer Eigenschaften, Auswertung von Wahrscheinlichkeiten, Berechnung von Quantilen und Ziehung von Zufallsstichproben.
 
 ## Arbeiten mit einer Verteilung
 
-[//]: # (<!---FUN distWorkingWithDistribution-->)
+{/*---FUN distWorkingWithDistribution--*/}
 
 ```kotlin
 val normal = NormalDistribution(mu = 0.0, sigma = 1.0)
@@ -35,7 +35,7 @@ normal.sample(Random(42))           // single random draw
 normal.sample(5, Random(42))        // 5 random draws
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Gemeinsame API
 
@@ -67,7 +67,7 @@ Konstruktoren validieren Parameter sofort. Ungültige Werte (negative Standardab
 
         **Parameter:** `mu` — Mittelwert, `sigma` — Standardabweichung (muss positiv sein)
 
-[//]: # (<!---FUN distNormal-->)
+{/*---FUN distNormal--*/}
 
 ```kotlin
 val d = NormalDistribution(mu = 100.0, sigma = 15.0)
@@ -76,7 +76,7 @@ d.cdf(115.0) // 0.8413
 d.quantile(0.975) // 129.3994
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden, wenn Daten annähernd symmetrisch und unbeschränkt sind.
       </Accordion>
@@ -86,7 +86,7 @@ d.quantile(0.975) // 129.3994
 
         **Parameter:** `df` — Freiheitsgrade (muss positiv sein)
 
-[//]: # (<!---FUN distStudentT-->)
+{/*---FUN distStudentT--*/}
 
 ```kotlin
 val d = StudentTDistribution(degreesOfFreedom = 10.0)
@@ -95,7 +95,7 @@ d.cdf(2.228) // ≈ 0.975
 d.quantile(0.975) // 2.2281
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Konfidenzintervalle und t-Tests bei kleinem Stichprobenumfang.
       </Accordion>
@@ -105,7 +105,7 @@ d.quantile(0.975) // 2.2281
 
         **Parameter:** `location` — Zentrum, `scale` — Skalenparameter (muss positiv sein)
 
-[//]: # (<!---FUN distLogistic-->)
+{/*---FUN distLogistic--*/}
 
 ```kotlin
 val d = LogisticDistribution(mu = 0.0, scale = 1.0)
@@ -114,7 +114,7 @@ d.cdf(0.0)   // 0.5
 d.pdf(0.0)   // 0.25
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden, wenn eine geschlossene CDF benötigt wird oder die Daten etwas schwerere Ränder als die Normalverteilung aufweisen.
       </Accordion>
@@ -124,7 +124,7 @@ d.pdf(0.0)   // 0.25
 
         **Parameter:** `location` — Zentrum (Median), `scale` — Halbwertsbreite bei halber Maximalhöhe (muss positiv sein)
 
-[//]: # (<!---FUN distCauchy-->)
+{/*---FUN distCauchy--*/}
 
 ```kotlin
 val d = CauchyDistribution(location = 0.0, scale = 1.0)
@@ -133,7 +133,7 @@ d.cdf(0.0)        // 0.5
 d.quantile(0.75)  // 1.0
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden bei Daten mit extremen Ausreißern, bei denen der Mittelwert keine aussagekräftige Zusammenfassung ist.
       </Accordion>
@@ -143,7 +143,7 @@ d.quantile(0.75)  // 1.0
 
         **Parameter:** `location` — Zentrum (Mittelwert und Median), `scale` — Skalenparameter (muss positiv sein)
 
-[//]: # (<!---FUN distLaplace-->)
+{/*---FUN distLaplace--*/}
 
 ```kotlin
 val d = LaplaceDistribution(mu = 0.0, scale = 1.0)
@@ -152,7 +152,7 @@ d.variance   // 2.0
 d.pdf(0.0)   // 0.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden bei Daten mit einer scharfen Spitze im Zentrum und exponentiellen Rändern.
       </Accordion>
@@ -166,7 +166,7 @@ d.pdf(0.0)   // 0.5
 
         **Parameter:** `rate` — Ereignisrate, der Kehrwert des Mittelwerts (muss positiv sein)
 
-[//]: # (<!---FUN distExponential-->)
+{/*---FUN distExponential--*/}
 
 ```kotlin
 val d = ExponentialDistribution(rate = 2.0)
@@ -175,7 +175,7 @@ d.cdf(1.0)   // 0.8647
 d.quantile(0.5) // 0.3466
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Wartezeiten, Dauern und Zwischenankunftszeiten.
       </Accordion>
@@ -185,7 +185,7 @@ d.quantile(0.5) // 0.3466
 
         **Parameter:** `shape` — Formparameter $k$ (muss positiv sein), `scale` — Skalenparameter $\theta$ (muss positiv sein)
 
-[//]: # (<!---FUN distGamma-->)
+{/*---FUN distGamma--*/}
 
 ```kotlin
 val d = GammaDistribution(shape = 2.0, rate = 0.5)
@@ -194,7 +194,7 @@ d.variance   // 8.0
 d.cdf(4.0)   // 0.5940
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für positive stetige Daten mit Rechtsschiefe, etwa aggregierte Wartezeiten oder Niederschlagsmengen.
       </Accordion>
@@ -204,7 +204,7 @@ d.cdf(4.0)   // 0.5940
 
         **Parameter:** `shape` — Form $k$ (muss positiv sein), `scale` — Skala $\lambda$ (muss positiv sein)
 
-[//]: # (<!---FUN distWeibull-->)
+{/*---FUN distWeibull--*/}
 
 ```kotlin
 val d = WeibullDistribution(shape = 1.5, scale = 1.0)
@@ -212,7 +212,7 @@ d.mean       // 0.9027
 d.cdf(1.0)   // 0.6321
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Ausfallzeitdaten, Windgeschwindigkeitsmodellierung und Überlebensanalysen.
       </Accordion>
@@ -222,7 +222,7 @@ d.cdf(1.0)   // 0.6321
 
         **Parameter:** `mu` — Mittelwert des Logarithmus, `sigma` — Standardabweichung des Logarithmus (muss positiv sein)
 
-[//]: # (<!---FUN distLogNormal-->)
+{/*---FUN distLogNormal--*/}
 
 ```kotlin
 val d = LogNormalDistribution(mu = 0.0, sigma = 1.0)
@@ -231,7 +231,7 @@ d.quantile(0.5) // 1.0
 d.cdf(1.0)      // 0.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für multiplikative Prozesse: Aktienkurse, biologische Messungen, Dateigrößen.
       </Accordion>
@@ -241,7 +241,7 @@ d.cdf(1.0)      // 0.5
 
         **Parameter:** `shape` — Form $m \ge 0{,}5$, `spread` — Streuung $\Omega$ (muss positiv sein)
 
-[//]: # (<!---FUN distNakagami-->)
+{/*---FUN distNakagami--*/}
 
 ```kotlin
 val d = NakagamiDistribution(mu = 1.0, omega = 1.0)
@@ -249,7 +249,7 @@ d.mean       // 0.8862
 d.variance   // 0.2146
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für die Modellierung von Signalhüllkurven in Schwundkanälen.
       </Accordion>
@@ -259,7 +259,7 @@ d.variance   // 0.2146
 
         **Parameter:** `location` — Verschiebungsparameter, `scale` — Skalenparameter (muss positiv sein)
 
-[//]: # (<!---FUN distLevy-->)
+{/*---FUN distLevy--*/}
 
 ```kotlin
 val d = LevyDistribution(mu = 0.0, c = 1.0)
@@ -267,7 +267,7 @@ d.cdf(1.0)   // 0.3173
 d.sf(1.0)    // 0.6827
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Extremwertmodellierung mit sehr schweren rechten Rändern.
       </Accordion>
@@ -281,7 +281,7 @@ d.sf(1.0)    // 0.6827
 
         **Parameter:** `alpha` — Form $\alpha$ (muss positiv sein), `beta` — Form $\beta$ (muss positiv sein)
 
-[//]: # (<!---FUN distBeta-->)
+{/*---FUN distBeta--*/}
 
 ```kotlin
 val d = BetaDistribution(alpha = 2.0, beta = 5.0)
@@ -290,7 +290,7 @@ d.cdf(0.3)   // 0.5798
 d.pdf(0.2)   // 2.4576
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Anteile, Wahrscheinlichkeiten und beschränkte Daten auf [0, 1].
       </Accordion>
@@ -300,7 +300,7 @@ d.pdf(0.2)   // 2.4576
 
         **Parameter:** `a` — untere Grenze, `b` — obere Grenze (es muss `a < b` gelten)
 
-[//]: # (<!---FUN distUniform-->)
+{/*---FUN distUniform--*/}
 
 ```kotlin
 val d = UniformDistribution(min = 0.0, max = 10.0)
@@ -309,7 +309,7 @@ d.variance   // 8.3333
 d.cdf(3.0)   // 0.3
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden, wenn alle Werte in einem Bereich gleich wahrscheinlich sind.
       </Accordion>
@@ -319,7 +319,7 @@ d.cdf(3.0)   // 0.3
 
         **Parameter:** `a` — Minimum, `b` — Maximum, `c` — Modus (es muss `a ≤ c ≤ b` gelten)
 
-[//]: # (<!---FUN distTriangular-->)
+{/*---FUN distTriangular--*/}
 
 ```kotlin
 val d = TriangularDistribution(a = 0.0, b = 10.0, c = 3.0)
@@ -327,7 +327,7 @@ d.mean       // 4.3333
 d.cdf(3.0)   // 0.3
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für grobe Schätzungen, wenn nur Minimum, Maximum und wahrscheinlichster Wert bekannt sind.
       </Accordion>
@@ -341,7 +341,7 @@ d.cdf(3.0)   // 0.3
 
         **Parameter:** `xm` — Minimalwert (Skala, muss positiv sein), `alpha` — Form (Randindex, muss positiv sein)
 
-[//]: # (<!---FUN distPareto-->)
+{/*---FUN distPareto--*/}
 
 ```kotlin
 val d = ParetoDistribution(shape = 2.0, scale = 1.0)
@@ -349,7 +349,7 @@ d.mean       // 2.0
 d.cdf(2.0)   // 0.75
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Vermögensverteilungen, Stadtgrößen und Dateigrößen.
       </Accordion>
@@ -359,7 +359,7 @@ d.cdf(2.0)   // 0.75
 
         **Parameter:** `location` — Modus, `scale` — Streuung (muss positiv sein)
 
-[//]: # (<!---FUN distGumbel-->)
+{/*---FUN distGumbel--*/}
 
 ```kotlin
 val d = GumbelDistribution(mu = 0.0, beta = 1.0)
@@ -367,7 +367,7 @@ d.mean       // 0.5772
 d.cdf(0.0)   // 0.3679
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Extremwertanalysen: Höchsttemperaturen, Hochwasserstände, strukturelle Belastungen.
       </Accordion>
@@ -377,7 +377,7 @@ d.cdf(0.0)   // 0.3679
 
         **Parameter:** `df` — Freiheitsgrade (muss positiv sein)
 
-[//]: # (<!---FUN distChiSquared-->)
+{/*---FUN distChiSquared--*/}
 
 ```kotlin
 val d = ChiSquaredDistribution(degreesOfFreedom = 5.0)
@@ -386,7 +386,7 @@ d.variance   // 10.0
 d.cdf(11.07) // ≈ 0.95
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Intern für Chi-Quadrat-Tests oder direkte Varianzinferenz verwenden.
       </Accordion>
@@ -396,7 +396,7 @@ d.cdf(11.07) // ≈ 0.95
 
         **Parameter:** `df1` — Zähler-Freiheitsgrade (muss positiv sein), `df2` — Nenner-Freiheitsgrade (muss positiv sein)
 
-[//]: # (<!---FUN distF-->)
+{/*---FUN distF--*/}
 
 ```kotlin
 val d = FDistribution(dfNumerator = 5.0, dfDenominator = 10.0)
@@ -404,7 +404,7 @@ d.mean       // 1.25
 d.cdf(3.33)  // ≈ 0.95
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Intern für ANOVA und F-Tests verwenden.
       </Accordion>
@@ -422,7 +422,7 @@ d.cdf(3.33)  // ≈ 0.95
 
         **Parameter:** `lambda` — erwartete Anzahl der Ereignisse (muss positiv sein)
 
-[//]: # (<!---FUN distPoisson-->)
+{/*---FUN distPoisson--*/}
 
 ```kotlin
 val d = PoissonDistribution(rate = 3.0)
@@ -432,7 +432,7 @@ d.cdf(5)        // 0.9161
 d.quantileInt(0.95) // 6
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Zähldaten: Defekte pro Charge, Ankünfte pro Stunde, Ereignisse pro Tag.
       </Accordion>
@@ -442,7 +442,7 @@ d.quantileInt(0.95) // 6
 
         **Parameter:** `trials` — Anzahl der Versuche (muss nicht-negativ sein), `probability` — Erfolgswahrscheinlichkeit pro Versuch (muss in [0, 1] liegen)
 
-[//]: # (<!---FUN distBinomial-->)
+{/*---FUN distBinomial--*/}
 
 ```kotlin
 val d = BinomialDistribution(trials = 10, probability = 0.3)
@@ -452,7 +452,7 @@ d.cdf(3)        // 0.6496
 d.quantileInt(0.5) // 3
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Ja/Nein-Experimente, die eine bekannte Anzahl von Malen wiederholt werden.
       </Accordion>
@@ -462,7 +462,7 @@ d.quantileInt(0.5) // 3
 
         **Parameter:** `r` — Anzahl der Erfolge (muss positiv sein), `p` — Erfolgswahrscheinlichkeit (muss in (0, 1] liegen)
 
-[//]: # (<!---FUN distNegativeBinomial-->)
+{/*---FUN distNegativeBinomial--*/}
 
 ```kotlin
 val d = NegativeBinomialDistribution(successes = 5, probability = 0.5)
@@ -471,7 +471,7 @@ d.variance      // 10.0
 d.pmf(3)        // probability of exactly 3 failures before 5 successes
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für überdisperse Zähldaten oder zur Modellierung der Versuchsanzahl bis zum Erreichen eines Ziels.
       </Accordion>
@@ -481,7 +481,7 @@ d.pmf(3)        // probability of exactly 3 failures before 5 successes
 
         **Parameter:** `probability` — Erfolgswahrscheinlichkeit pro Versuch (muss in (0, 1] liegen)
 
-[//]: # (<!---FUN distGeometric-->)
+{/*---FUN distGeometric--*/}
 
 ```kotlin
 val d = GeometricDistribution(probability = 0.3)
@@ -490,7 +490,7 @@ d.pmf(1)        // 0.3
 d.cdf(3)        // 0.657
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Fragen der Art „wie viele Versuche bis zum Erfolg".
       </Accordion>
@@ -504,7 +504,7 @@ d.cdf(3)        // 0.657
 
         **Parameter:** `populationSize` — Gesamtpopulation, `successStates` — Anzahl der Erfolgselemente, `trials` — Anzahl der Ziehungen
 
-[//]: # (<!---FUN distHypergeometric-->)
+{/*---FUN distHypergeometric--*/}
 
 ```kotlin
 val d = HypergeometricDistribution(population = 50, successes = 10, draws = 5)
@@ -512,7 +512,7 @@ d.mean          // 1.0
 d.pmf(2)        // probability of exactly 2 successes in 5 draws
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden, wenn Ziehen ohne Zurücklegen relevant ist: Qualitätskontrolle, Kartenspiele, Lotterieprobleme.
       </Accordion>
@@ -522,7 +522,7 @@ d.pmf(2)        // probability of exactly 2 successes in 5 draws
 
         **Parameter:** `trials` — Anzahl der Versuche, `alpha` — Beta-Formparameter, `beta` — Beta-Formparameter
 
-[//]: # (<!---FUN distBetaBinomial-->)
+{/*---FUN distBetaBinomial--*/}
 
 ```kotlin
 val d = BetaBinomialDistribution(trials = 10, alpha = 2.0, beta = 3.0)
@@ -530,7 +530,7 @@ d.mean          // 4.0
 d.pmf(4)        // probability of exactly 4 successes
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für überdisperse Binomialdaten, bei denen die Erfolgswahrscheinlichkeit variiert.
       </Accordion>
@@ -544,7 +544,7 @@ d.pmf(4)        // probability of exactly 4 successes
 
         **Parameter:** `probability` — Erfolgswahrscheinlichkeit (muss in [0, 1] liegen)
 
-[//]: # (<!---FUN distBernoulli-->)
+{/*---FUN distBernoulli--*/}
 
 ```kotlin
 val d = BernoulliDistribution(probability = 0.7)
@@ -553,7 +553,7 @@ d.pmf(1)        // 0.7
 d.pmf(0)        // 0.3
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Münzwurf-ähnliche binäre Ergebnisse.
       </Accordion>
@@ -563,7 +563,7 @@ d.pmf(0)        // 0.3
 
         **Parameter:** `a` — untere Grenze, `b` — obere Grenze (es muss `a ≤ b` gelten)
 
-[//]: # (<!---FUN distUniformDiscrete-->)
+{/*---FUN distUniformDiscrete--*/}
 
 ```kotlin
 val d = UniformDiscreteDistribution(min = 1, max = 6)
@@ -572,7 +572,7 @@ d.pmf(3)        // 0.1667
 d.cdf(3)        // 0.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für faire Würfel und gleichverteilte ganzzahlige Zufallsauswahl.
       </Accordion>
@@ -586,7 +586,7 @@ d.cdf(3)        // 0.5
 
         **Parameter:** `n` — Anzahl der Elemente (muss positiv sein), `s` — Exponent (muss positiv sein)
 
-[//]: # (<!---FUN distZipf-->)
+{/*---FUN distZipf--*/}
 
 ```kotlin
 val d = ZipfDistribution(numberOfElements = 100, exponent = 1.0)
@@ -594,7 +594,7 @@ d.pmf(1)        // probability of rank 1 (the most common)
 d.pmf(100)      // probability of rank 100 (the least common)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Worthäufigkeiten, Stadtgrößen und Website-Traffic-Verteilungen.
       </Accordion>
@@ -604,7 +604,7 @@ d.pmf(100)      // probability of rank 100 (the least common)
 
         **Parameter:** `p` — Parameter in (0, 1)
 
-[//]: # (<!---FUN distLogarithmic-->)
+{/*---FUN distLogarithmic--*/}
 
 ```kotlin
 val d = LogarithmicDistribution(probability = 0.5)
@@ -613,7 +613,7 @@ d.pmf(1)        // 0.7213
 d.pmf(2)        // 0.1803
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Verwenden für Artenabundanzdaten und ähnliche langschwänzige Zählverteilungen.
       </Accordion>

--- a/docs/de/getting-started/introduction.mdx
+++ b/docs/de/getting-started/introduction.mdx
@@ -3,11 +3,11 @@ title: "Introduction"
 description: "kstats ist eine abhängigkeitsfreie Kotlin-Multiplatform-Statistikbibliothek für deskriptive Statistik, Verteilungen, Hypothesentests, Korrelation und Stichprobenziehung."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
 
 kstats ist eine abhängigkeitsfreie Kotlin-Multiplatform-Statistikbibliothek. Sie deckt deskriptive Statistik, Wahrscheinlichkeitsverteilungen, Hypothesentests, Korrelation und Regression sowie Stichprobenziehung ab — alles, was für quantitative Analysen in Kotlin benötigt wird.
 
-[//]: # (<!---FUN introOverview-->)
+{/*---FUN introOverview--*/}
 
 ```kotlin
 val sample = doubleArrayOf(2.0, 4.0, 4.0, 5.0, 7.0, 9.0)
@@ -23,7 +23,7 @@ val fitted = NormalDistribution(mu = summary.mean, sigma = summary.standardDevia
 fitted.cdf(6.0)           // 0.6335
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Module
 

--- a/docs/de/getting-started/quickstart.mdx
+++ b/docs/de/getting-started/quickstart.mdx
@@ -3,15 +3,15 @@ title: "Quickstart"
 description: "Deskriptive Statistiken berechnen, eine Verteilung anpassen, einen Hypothesentest durchführen und Korrelation messen — in fünf Minuten."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.samples.DocsSamples--*/}
 
-[//]: # (<!---IMPORT org.oremif.kstats.distributions.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.distributions.samples.DocsSamples--*/}
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
 
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.correlation.samples.DocsSamples--*/}
 
-[//]: # (<!---IMPORT org.oremif.kstats.sampling.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.sampling.samples.DocsSamples--*/}
 
 Beginnen Sie mit dem durchgängigen Szenario unten, oder springen Sie direkt zu den modulspezifischen Beispielen am Ende der Seite.
 
@@ -19,17 +19,17 @@ Beginnen Sie mit dem durchgängigen Szenario unten, oder springen Sie direkt zu 
 
 ### Stichprobe definieren
 
-[//]: # (<!---FUN quickstartDefine-->)
+{/*---FUN quickstartDefine--*/}
 
 ```kotlin
 val sample = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Zusammenfassen
 
-[//]: # (<!---FUN quickstartSummarize-->)
+{/*---FUN quickstartSummarize--*/}
 
 ```kotlin
 val stats = sample.describe()
@@ -40,13 +40,13 @@ stats.skewness          // 0.6563
 stats.interquartileRange // 1.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 `describe()` liefert Anzahl, Lagemaße, Streuungsmaße, Quartile, Formkennzahlen und Standardfehler in einem einzigen Objekt.
 
 ### Normalität prüfen
 
-[//]: # (<!---FUN quickstartNormality-->)
+{/*---FUN quickstartNormality--*/}
 
 ```kotlin
 val normality = shapiroWilkTest(sample)
@@ -55,11 +55,11 @@ normality.pValue             // > 0.05 → no evidence against normality
 normality.isSignificant()    // false
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Verteilung anpassen
 
-[//]: # (<!---FUN quickstartFit-->)
+{/*---FUN quickstartFit--*/}
 
 ```kotlin
 val normal = NormalDistribution(mu = stats.mean, sigma = stats.standardDeviation)
@@ -67,11 +67,11 @@ normal.cdf(6.0)          // probability that X ≤ 6.0
 normal.quantile(0.95)    // value below which 95% of the distribution falls
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Hypothese testen
 
-[//]: # (<!---FUN quickstartHypothesis-->)
+{/*---FUN quickstartHypothesis--*/}
 
 ```kotlin
 val result = tTest(sample, mu = 5.0)
@@ -81,11 +81,11 @@ result.isSignificant()   // false — cannot reject H₀: μ = 5.0
 result.confidenceInterval // (3.21, 6.79)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Zusammenhang messen
 
-[//]: # (<!---FUN quickstartAssociation-->)
+{/*---FUN quickstartAssociation--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -101,14 +101,14 @@ model.rSquared           // 0.9973
 model.predict(6.0)       // 11.99
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Modulspezifische Beispiele
 
 <Tabs>
   <Tab title="Core">
 
-[//]: # (<!---FUN quickstartTabCore-->)
+{/*---FUN quickstartTabCore--*/}
 
 ```kotlin
 val data = doubleArrayOf(2.0, 4.0, 4.0, 5.0, 7.0, 9.0)
@@ -119,11 +119,11 @@ val summary = data.describe()
 summary.skewness          // 0.3942
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
   </Tab>
   <Tab title="Verteilungen">
 
-[//]: # (<!---FUN quickstartTabDistributions-->)
+{/*---FUN quickstartTabDistributions--*/}
 
 ```kotlin
 val normal = NormalDistribution(mu = 0.0, sigma = 1.0)
@@ -136,11 +136,11 @@ poisson.pmf(5)            // 0.1008
 poisson.cdf(5)            // 0.9161
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
   </Tab>
   <Tab title="Hypothesentests">
 
-[//]: # (<!---FUN quickstartTabHypothesis-->)
+{/*---FUN quickstartTabHypothesis--*/}
 
 ```kotlin
 val sample = doubleArrayOf(5.1, 4.9, 5.3, 5.0, 4.8)
@@ -151,11 +151,11 @@ result.isSignificant()    // true or false at α = 0.05
 result.confidenceInterval // one-sided CI
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
   </Tab>
   <Tab title="Korrelation">
 
-[//]: # (<!---FUN quickstartTabCorrelation-->)
+{/*---FUN quickstartTabCorrelation--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -165,11 +165,11 @@ pearsonCorrelation(x, y).coefficient  // 0.9987
 simpleLinearRegression(x, y).slope    // 1.99
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
   </Tab>
   <Tab title="Sampling">
 
-[//]: # (<!---FUN quickstartTabSampling-->)
+{/*---FUN quickstartTabSampling--*/}
 
 ```kotlin
 val data = doubleArrayOf(3.0, 1.0, 4.0, 1.0, 5.0)
@@ -178,7 +178,7 @@ data.zScore()             // [-0.16, -1.47, 0.49, -1.47, 1.14]
 data.minMaxNormalize()    // [0.5, 0.0, 0.75, 0.0, 1.0]
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
   </Tab>
 </Tabs>
 

--- a/docs/de/guides/how-to/ab-testing.mdx
+++ b/docs/de/guides/how-to/ab-testing.mdx
@@ -3,8 +3,8 @@ title: "A/B Testing — Varianten mit statistischen Tests vergleichen"
 description: "Führen Sie einen vollständigen A/B-Test-Workflow in Kotlin durch: Gruppen zusammenfassen, Annahmen prüfen, Effektgröße messen und für multiples Testen korrigieren mit kstats."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.correlation.samples.DocsSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/ab-testing.ipynb">
   Probieren Sie diesen Leitfaden als Kotlin Notebook mit Kandy-Visualisierungen aus — führen Sie die Zellen aus, um Diagramme zu sehen und die Daten interaktiv zu erkunden.
@@ -15,7 +15,7 @@ Dieser Leitfaden führt Sie durch einen A/B-Test, der zwei Varianten eines Check
 
 ## Experimentdaten
 
-[//]: # (<!---FUN abTestingData-->)
+{/*---FUN abTestingData--*/}
 
 ```kotlin
 // Variant A (control): original checkout flow
@@ -31,11 +31,11 @@ val treatmentDurationSec = doubleArrayOf(
 )
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Schritt 1: Beide Gruppen zusammenfassen
 
-[//]: # (<!---FUN abTestingSummarize-->)
+{/*---FUN abTestingSummarize--*/}
 
 ```kotlin
 val controlSummary = controlDurationSec.describe()
@@ -47,13 +47,13 @@ controlSummary.standardDeviation   // control spread
 treatmentSummary.standardDeviation // treatment spread
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Schritt 2: Annahmen prüfen
 
 ### Normalität
 
-[//]: # (<!---FUN abTestingNormality-->)
+{/*---FUN abTestingNormality--*/}
 
 ```kotlin
 val controlNormality = shapiroWilkTest(controlDurationSec)
@@ -63,25 +63,25 @@ controlNormality.pValue
 treatmentNormality.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Varianzhomogenität
 
-[//]: # (<!---FUN abTestingVariance-->)
+{/*---FUN abTestingVariance--*/}
 
 ```kotlin
 val variances = leveneTest(controlDurationSec, treatmentDurationSec)
 variances.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Schritt 3: Test auswählen und durchführen
 
 <Tabs>
 <Tab title="Parametrisch (normalverteilte Daten)">
 
-[//]: # (<!---FUN abTestingTTest-->)
+{/*---FUN abTestingTTest--*/}
 
 ```kotlin
 // Welch's t-test (default: equalVariances = false)
@@ -93,11 +93,11 @@ result.confidenceInterval // 95% CI for the difference in means
 result.isSignificant()    // true if p < 0.05
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Wenn der Levene-Test gleiche Varianzen bestätigt hat:
 
-[//]: # (<!---FUN abTestingTTestEqual-->)
+{/*---FUN abTestingTTestEqual--*/}
 
 ```kotlin
 val equalVar = tTest(
@@ -108,12 +108,12 @@ val equalVar = tTest(
 equalVar.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 <Tab title="Nicht-parametrisch (nicht-normalverteilte Daten)">
 
-[//]: # (<!---FUN abTestingMannWhitney-->)
+{/*---FUN abTestingMannWhitney--*/}
 
 ```kotlin
 val result = mannWhitneyUTest(controlDurationSec, treatmentDurationSec)
@@ -123,7 +123,7 @@ result.pValue
 result.isSignificant()
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 </Tabs>
@@ -132,7 +132,7 @@ result.isSignificant()
 
 Ein <Tooltip tip="Standardisiertes Maß für die Größe eines Unterschieds, unabhängig von der Stichprobengröße">p-Wert</Tooltip> sagt Ihnen, *ob* ein Unterschied existiert; die Effektgröße sagt Ihnen, *wie groß* er ist. Cohens d drückt den Unterschied in Standardabweichungseinheiten aus: |d| < 0,2 vernachlässigbar, 0,2 klein, 0,5 mittel, 0,8+ groß.
 
-[//]: # (<!---FUN abTestingEffectSize-->)
+{/*---FUN abTestingEffectSize--*/}
 
 ```kotlin
 // Cohen's d: how large is the difference in standard-deviation units?
@@ -140,13 +140,13 @@ val d = cohensD(controlDurationSec, treatmentDurationSec)
 d // ~2.9 → large effect (|d| ≥ 0.8)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Einseitige Tests
 
 Wenn Sie erwarten, dass die Behandlung die Sitzungsdauer verkürzt:
 
-[//]: # (<!---FUN abTestingOneSided-->)
+{/*---FUN abTestingOneSided--*/}
 
 ```kotlin
 val oneSided = tTest(
@@ -157,13 +157,13 @@ val oneSided = tTest(
 oneSided.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Schritt 4: Zweite Metrik testen
 
 Wenden Sie denselben Workflow auf die sekundäre Metrik an.
 
-[//]: # (<!---FUN abTestingSecondMetric-->)
+{/*---FUN abTestingSecondMetric--*/}
 
 ```kotlin
 // Number of completed checkout steps per session
@@ -184,13 +184,13 @@ stepsResult.pValue
 stepsResult.isSignificant()
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Korrektur für multiples Testen
 
 Das Testen von zwei Metriken (Dauer und Schritte) erhöht die Falsch-Positiv-Rate. Die <Tooltip tip="Sequentiell ablehnende Methode, die die familienweise Fehlerrate kontrolliert und dabei leistungsfähiger als Bonferroni ist">Holm-Bonferroni</Tooltip>-Korrektur passt die p-Werte entsprechend an.
 
-[//]: # (<!---FUN abTestingMultipleComparison-->)
+{/*---FUN abTestingMultipleComparison--*/}
 
 ```kotlin
 // Correct for testing two metrics (duration + steps)
@@ -201,13 +201,13 @@ corrected[0] // adjusted p-value for duration
 corrected[1] // adjusted p-value for steps
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Schritt 5: Korrelation zwischen Metriken
 
 Prüfen Sie, ob die beiden Metriken innerhalb jeder Gruppe zusammenhängen.
 
-[//]: # (<!---FUN abTestingCorrelation-->)
+{/*---FUN abTestingCorrelation--*/}
 
 ```kotlin
 // Within the treatment group: do faster sessions correlate with more completed steps?
@@ -217,7 +217,7 @@ correlation.coefficient // negative means shorter sessions correlate with more s
 correlation.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 Spearman-Korrelation wird hier bevorzugt, da eine der Metriken (Schritte) ordinal ist.
@@ -227,7 +227,7 @@ Spearman-Korrelation wird hier bevorzugt, da eine der Metriken (Schritte) ordina
 
 Wenn dieselben Nutzer vor und nach einer Änderung gemessen werden, verwenden Sie gepaarte Tests.
 
-[//]: # (<!---FUN abTestingPaired-->)
+{/*---FUN abTestingPaired--*/}
 
 ```kotlin
 val beforeMs = doubleArrayOf(
@@ -251,4 +251,4 @@ val dz = differences.mean() / differences.standardDeviation()
 dz // ~6.1 → large effect
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}

--- a/docs/de/guides/how-to/building-a-pipeline.mdx
+++ b/docs/de/guides/how-to/building-a-pipeline.mdx
@@ -3,8 +3,8 @@ title: "Statistik-Pipeline erstellen"
 description: "kstats-Aufrufe in wiederverwendbare Funktionen für reproduzierbare Analyse-Workflows organisieren."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.PipelineSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.PipelineSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.PipelineSamples--*/}
+{/*---IMPORT org.oremif.kstats.correlation.samples.PipelineSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/building-a-pipeline.ipynb">
   Probieren Sie diesen Leitfaden als Kotlin Notebook mit Kandy-Visualisierungen aus — führen Sie die Zellen aus, um Diagramme zu sehen und die Daten interaktiv zu erkunden.
@@ -15,7 +15,7 @@ Wenn die Analyse über einzelne Aufrufe hinauswächst, sorgen typisierte Pipelin
 
 ## Ergebnistypen
 
-[//]: # (<!---FUN pipelineResultTypes-->)
+{/*---FUN pipelineResultTypes--*/}
 
 ```kotlin
 data class AssumptionCheck(
@@ -40,11 +40,11 @@ data class AnalysisReport(
 )
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Voraussetzungen prüfen
 
-[//]: # (<!---FUN pipelineCheckAssumptions-->)
+{/*---FUN pipelineCheckAssumptions--*/}
 
 ```kotlin
 fun checkAssumptions(
@@ -67,13 +67,13 @@ fun checkAssumptions(
 }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Gruppen vergleichen
 
 Den Test automatisch anhand der Voraussetzungsprüfung auswählen.
 
-[//]: # (<!---FUN pipelineCompareGroups-->)
+{/*---FUN pipelineCompareGroups--*/}
 
 ```kotlin
 fun compareGroups(
@@ -97,11 +97,11 @@ fun compareGroups(
 }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Vollständiger Bericht
 
-[//]: # (<!---FUN pipelineFullReport-->)
+{/*---FUN pipelineFullReport--*/}
 
 ```kotlin
 fun analyze(
@@ -121,11 +121,11 @@ fun analyze(
 }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Verwendung
 
-[//]: # (<!---FUN pipelineUsage-->)
+{/*---FUN pipelineUsage--*/}
 
 ```kotlin
 val pageLoadControl = doubleArrayOf(
@@ -149,13 +149,13 @@ report.comparison.isSignificant
 report.comparison.confidenceInterval
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Die Pipeline erweitern
 
 Korrelationsanalyse zwischen Metriken hinzufügen:
 
-[//]: # (<!---FUN pipelineExtended-->)
+{/*---FUN pipelineExtended--*/}
 
 ```kotlin
 data class ExtendedReport(
@@ -186,7 +186,7 @@ fun analyzeWithCorrelation(
 }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Modulzuständigkeiten
 

--- a/docs/de/guides/how-to/choosing-a-distribution.mdx
+++ b/docs/de/guides/how-to/choosing-a-distribution.mdx
@@ -3,8 +3,8 @@ title: "Verteilung auswählen"
 description: "Ordnen Sie Ihre Daten der richtigen Wahrscheinlichkeitsverteilung zu — mit praxisnahen Beispielen und Verifikation."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.distributions.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.distributions.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/choosing-a-distribution.ipynb">
   Probieren Sie diesen Leitfaden als Kotlin Notebook mit Kandy-Visualisierungen aus — führen Sie die Zellen aus, um Diagramme zu sehen und die Daten interaktiv zu erkunden.
@@ -33,7 +33,7 @@ Jede Verteilung kodiert Annahmen darüber, welche Werte möglich sind und wie wa
 <Tabs>
 <Tab title="Antwortzeiten">
 
-[//]: # (<!---FUN choosingResponseTimes-->)
+{/*---FUN choosingResponseTimes--*/}
 
 ```kotlin
 // API response times — often right-skewed with a long tail
@@ -45,12 +45,12 @@ responseTime.quantile(0.99)    // P99 latency
 responseTime.cdf(200.0)        // probability of responding under 200ms
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 <Tab title="Zeit zwischen Ereignissen">
 
-[//]: # (<!---FUN choosingTimeBetweenEvents-->)
+{/*---FUN choosingTimeBetweenEvents--*/}
 
 ```kotlin
 // Time between server errors — memoryless waiting process
@@ -61,12 +61,12 @@ timeBetweenErrors.sf(10.0)      // probability of waiting longer than 10 units
 timeBetweenErrors.quantile(0.5) // median waiting time
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 <Tab title="Komponentenlebensdauer">
 
-[//]: # (<!---FUN choosingComponentLifetime-->)
+{/*---FUN choosingComponentLifetime--*/}
 
 ```kotlin
 // Hardware component lifetime — models wear-out (shape > 1) or burn-in (shape < 1)
@@ -77,7 +77,7 @@ componentLifetime.cdf(3000.0)    // probability of failure before 3000 hours
 componentLifetime.sf(4000.0)     // probability of surviving past 4000 hours
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 </Tabs>
@@ -87,7 +87,7 @@ componentLifetime.sf(4000.0)     // probability of surviving past 4000 hours
 <Tabs>
 <Tab title="Ereigniszählungen">
 
-[//]: # (<!---FUN choosingEventCounts-->)
+{/*---FUN choosingEventCounts--*/}
 
 ```kotlin
 // Errors per hour on a production server
@@ -98,12 +98,12 @@ errorsPerHour.cdf(5)            // probability of at most 5 errors
 errorsPerHour.quantileInt(0.99) // error count exceeded only 1% of the time
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 <Tab title="Feste Versuchsanzahl">
 
-[//]: # (<!---FUN choosingFixedTrials-->)
+{/*---FUN choosingFixedTrials--*/}
 
 ```kotlin
 // Conversions out of 1000 page views with 3.5% conversion rate
@@ -114,12 +114,12 @@ conversions.pmf(40) // probability of exactly 40 conversions
 conversions.sf(50)  // probability of more than 50 conversions
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 <Tab title="Überdispergierte Zählungen">
 
-[//]: # (<!---FUN choosingOverdispersed-->)
+{/*---FUN choosingOverdispersed--*/}
 
 ```kotlin
 // Support tickets until 5th resolution (variance > mean)
@@ -129,14 +129,14 @@ tickets.mean     // expected ticket count
 tickets.variance // larger than mean — overdispersion
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 </Tabs>
 
 ## Anteile und Raten
 
-[//]: # (<!---FUN choosingProportions-->)
+{/*---FUN choosingProportions--*/}
 
 ```kotlin
 // Click-through rate estimated from 120 clicks in 4000 impressions
@@ -148,11 +148,11 @@ ctr.quantile(0.975) // upper bound
 ctr.cdf(0.035)      // probability that true CTR is below 3.5%
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Allgemeine symmetrische Verteilungen
 
-[//]: # (<!---FUN choosingSymmetric-->)
+{/*---FUN choosingSymmetric--*/}
 
 ```kotlin
 // User session duration in minutes (roughly symmetric)
@@ -166,13 +166,13 @@ val smallSampleEstimate = StudentTDistribution(degreesOfFreedom = 8.0)
 smallSampleEstimate.quantile(0.975) // critical value for 95% CI
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Anpassungsgüte überprüfen
 
 Vergleichen Sie nach der Wahl einer Verteilung diese mit den beobachteten Daten mithilfe des Kolmogorov-Smirnov-Tests.
 
-[//]: # (<!---FUN choosingVerifyFit-->)
+{/*---FUN choosingVerifyFit--*/}
 
 ```kotlin
 val processingTimesMs = doubleArrayOf(
@@ -191,7 +191,7 @@ ks.statistic // KS statistic — smaller means better fit
 ks.pValue    // high p-value means data does not contradict the distribution
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 Ein nicht-signifikanter KS-Test beweist nicht, dass die Verteilung korrekt ist — er bedeutet lediglich, dass die Daten dieser Wahl nicht stark widersprechen.

--- a/docs/de/guides/how-to/exploratory-analysis.mdx
+++ b/docs/de/guides/how-to/exploratory-analysis.mdx
@@ -3,10 +3,10 @@ title: "Explorative Datenanalyse"
 description: "Einen vollständigen EDA-Workflow an einem einzelnen Datensatz durchführen — mit deskriptiver Statistik, Verteilungen, Korrelationen und Vergleichen."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.sampling.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.sampling.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.correlation.samples.DocsSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/exploratory-analysis.ipynb">
   Probieren Sie diesen Leitfaden als Kotlin Notebook mit Kandy-Visualisierungen aus — führen Sie die Zellen aus, um Diagramme zu sehen und die Daten interaktiv zu erkunden.
@@ -17,7 +17,7 @@ Diese Anleitung analysiert Performance-Metriken eines Backend-Dienstes, die übe
 
 ## Datensatz
 
-[//]: # (<!---FUN edaDataset-->)
+{/*---FUN edaDataset--*/}
 
 ```kotlin
 val responseTimeMs = doubleArrayOf(
@@ -45,11 +45,11 @@ val throughputRps = doubleArrayOf(
 )
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Schritt 1: Zusammenfassende Statistiken
 
-[//]: # (<!---FUN edaSummaryStats-->)
+{/*---FUN edaSummaryStats--*/}
 
 ```kotlin
 val rtSummary = responseTimeMs.describe()
@@ -63,11 +63,11 @@ memSummary.mean; memSummary.standardDeviation; memSummary.min; memSummary.max
 tpSummary.mean; tpSummary.standardDeviation; tpSummary.min; tpSummary.max
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Häufigkeitsverteilung
 
-[//]: # (<!---FUN edaFrequencyDistribution-->)
+{/*---FUN edaFrequencyDistribution--*/}
 
 ```kotlin
 val rtBins = responseTimeMs.frequencyTable(binCount = 5)
@@ -81,11 +81,11 @@ errBins.forEach { bin ->
 }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Schritt 2: Verteilungsform
 
-[//]: # (<!---FUN edaDistributionShape-->)
+{/*---FUN edaDistributionShape--*/}
 
 ```kotlin
 responseTimeMs.skewness() // positive = right-skewed
@@ -98,11 +98,11 @@ memoryUsageMb.skewness()
 throughputRps.skewness()
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Normalitätstests
 
-[//]: # (<!---FUN edaNormalityTests-->)
+{/*---FUN edaNormalityTests--*/}
 
 ```kotlin
 shapiroWilkTest(responseTimeMs).pValue
@@ -111,11 +111,11 @@ shapiroWilkTest(memoryUsageMb).pValue
 shapiroWilkTest(throughputRps).pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Anpassung einer Kandidatenverteilung
 
-[//]: # (<!---FUN edaFitDistribution-->)
+{/*---FUN edaFitDistribution--*/}
 
 ```kotlin
 val rtFit = NormalDistribution(
@@ -131,11 +131,11 @@ val memFit = NormalDistribution(
 kolmogorovSmirnovTest(memoryUsageMb, memFit).pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Schritt 3: Korrelationen
 
-[//]: # (<!---FUN edaCorrelations-->)
+{/*---FUN edaCorrelations--*/}
 
 ```kotlin
 // Correlation matrix across all four metrics
@@ -152,11 +152,11 @@ rtVsThroughput.coefficient // negative = latency rises when throughput drops
 rtVsThroughput.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Regression
 
-[//]: # (<!---FUN edaRegression-->)
+{/*---FUN edaRegression--*/}
 
 ```kotlin
 // Model: how does error count relate to response time?
@@ -169,13 +169,13 @@ regression.rSquared  // proportion of variance explained
 regression.predict(4.0) // expected latency at 4 errors/hour
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Schritt 4: Zeiträume vergleichen
 
 Die Daten in zwei Hälften aufteilen und prüfen, ob sich die Performance verändert hat.
 
-[//]: # (<!---FUN edaComparePeriods-->)
+{/*---FUN edaComparePeriods--*/}
 
 ```kotlin
 val firstHalfRt = responseTimeMs.sliceArray(0 until 15)
@@ -190,11 +190,11 @@ val periodRank = mannWhitneyUTest(firstHalfRt, secondHalfRt)
 periodRank.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Durchsatz zwischen Zeiträumen vergleichen:
 
-[//]: # (<!---FUN edaCompareThroughput-->)
+{/*---FUN edaCompareThroughput--*/}
 
 ```kotlin
 val firstHalfTp = throughputRps.sliceArray(0 until 15)
@@ -204,13 +204,13 @@ val tpComparison = tTest(firstHalfTp, secondHalfTp)
 tpComparison.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Schritt 5: Normalisieren und Rangordnung
 
 Metriken auf eine gemeinsame Skala bringen.
 
-[//]: # (<!---FUN edaNormalizeRank-->)
+{/*---FUN edaNormalizeRank--*/}
 
 ```kotlin
 // Z-score: values become standard deviations from mean
@@ -226,7 +226,7 @@ val tpScaled = throughputRps.minMaxNormalize()
 val rtRanked = responseTimeMs.rank()
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Z-Score-Normalisierung eignet sich gut, um Metriken zu einem Gesamtwert zu kombinieren:

--- a/docs/de/guides/how-to/quality-control.mdx
+++ b/docs/de/guides/how-to/quality-control.mdx
@@ -3,10 +3,10 @@ title: "Qualitätskontrolle"
 description: "Anomalien erkennen, Kontrollgrenzen festlegen und Prozessstabilität mit statistischen Methoden überwachen."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.sampling.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.sampling.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.correlation.samples.DocsSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/quality-control.ipynb">
   Probieren Sie diesen Leitfaden als Kotlin Notebook mit Kandy-Visualisierungen aus — führen Sie die Zellen aus, um Diagramme zu sehen und die Daten interaktiv zu erkunden.
@@ -17,7 +17,7 @@ Diese Anleitung verwendet Temperatursensor-Messwerte einer Fertigungslinie, um A
 
 ## Prozessdaten
 
-[//]: # (<!---FUN qcProcessData-->)
+{/*---FUN qcProcessData--*/}
 
 ```kotlin
 // Temperature readings (°C) from sensor on production line
@@ -29,13 +29,13 @@ val sensorReadings = doubleArrayOf(
 // Two potential outliers: 162.5 and 141.3
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Anomalieerkennung
 
 ### Basisstatistiken
 
-[//]: # (<!---FUN qcBaselineStats-->)
+{/*---FUN qcBaselineStats--*/}
 
 ```kotlin
 val summary = sensorReadings.describe()
@@ -47,13 +47,13 @@ summary.max // check for unusually high values
 summary.interquartileRange
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Z-Score-Methode
 
 Messwerte kennzeichnen, die mehr als 3 Standardabweichungen vom Mittelwert entfernt liegen.
 
-[//]: # (<!---FUN qcZScore-->)
+{/*---FUN qcZScore--*/}
 
 ```kotlin
 val zScores = sensorReadings.zScore()
@@ -62,13 +62,13 @@ val anomalyIndices = zScores.indices.filter { kotlin.math.abs(zScores[it]) > 3.0
 val anomalies = anomalyIndices.map { sensorReadings[it] }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Perzentilbasierte Erkennung
 
 Messwerte kennzeichnen, die außerhalb des 1. und 99. Perzentils liegen.
 
-[//]: # (<!---FUN qcPercentileDetection-->)
+{/*---FUN qcPercentileDetection--*/}
 
 ```kotlin
 val lowerBound = sensorReadings.quantile(0.01)
@@ -77,13 +77,13 @@ val upperBound = sensorReadings.quantile(0.99)
 val outliers = sensorReadings.filter { it < lowerBound || it > upperBound }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Kontrollgrenzen
 
 Mittelwert ± 3σ-Grenzen berechnen.
 
-[//]: # (<!---FUN qcControlLimits-->)
+{/*---FUN qcControlLimits--*/}
 
 ```kotlin
 val centerLine = sensorReadings.mean()
@@ -95,13 +95,13 @@ val lowerControlLimit = centerLine - 3 * sigma
 val outOfControl = sensorReadings.filter { it > upperControlLimit || it < lowerControlLimit }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Chargenstabilität
 
 Messwerte aus zwei Produktionschargen vergleichen, um zu prüfen, ob sich der Prozess verschoben hat.
 
-[//]: # (<!---FUN qcBatchStability-->)
+{/*---FUN qcBatchStability--*/}
 
 ```kotlin
 val morningBatch = doubleArrayOf(
@@ -124,11 +124,11 @@ batchComparison.pValue
 batchComparison.isSignificant() // false means no significant shift
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Mehrere Chargen
 
-[//]: # (<!---FUN qcMultipleBatches-->)
+{/*---FUN qcMultipleBatches--*/}
 
 ```kotlin
 val batch1 = doubleArrayOf(155.2, 154.8, 156.1, 155.5, 154.3)
@@ -140,13 +140,13 @@ anova.fStatistic
 anova.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Verteilungsanpassung
 
 Prüfen, ob die Messwerte der erwarteten Verteilung folgen.
 
-[//]: # (<!---FUN qcDistributionFit-->)
+{/*---FUN qcDistributionFit--*/}
 
 ```kotlin
 // Exclude known outliers for fitting
@@ -161,7 +161,7 @@ val ks = kolmogorovSmirnovTest(cleanReadings, fitted)
 ks.pValue // high p-value supports the normal process model
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Nach der Anpassung einer Prozessverteilung können mit `quantile()` Schwellenwerte gesetzt werden:
@@ -172,7 +172,7 @@ Nach der Anpassung einer Prozessverteilung können mit `quantile()` Schwellenwer
 
 Bei der Überwachung mehrerer Sensoren sollten die Korrelationen zwischen ihnen geprüft werden.
 
-[//]: # (<!---FUN qcMultiParameter-->)
+{/*---FUN qcMultiParameter--*/}
 
 ```kotlin
 val temperatureSensor = doubleArrayOf(
@@ -196,7 +196,7 @@ val matrix = correlationMatrix(temperatureSensor, pressureSensor, flowRateSensor
 // matrix[1][2] = pressure-flow correlation
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 Starke Korrelationen zwischen Sensormesswerten können auf gemeinsame Ursachen hinweisen, wenn ein Parameter außer Kontrolle gerät.

--- a/docs/de/guides/how-to/testing-assumptions.mdx
+++ b/docs/de/guides/how-to/testing-assumptions.mdx
@@ -3,7 +3,7 @@ title: "Annahmen überprüfen"
 description: "Überprüfen Sie Normalität, Varianzhomogenität und Verteilungsanpassung, bevor Sie parametrische Methoden anwenden."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/testing-assumptions.ipynb">
   Probieren Sie diesen Leitfaden als Kotlin Notebook mit Kandy-Visualisierungen aus — führen Sie die Zellen aus, um Diagramme zu sehen und die Daten interaktiv zu erkunden.
@@ -25,7 +25,7 @@ Parametrische Methoden (t-Tests, ANOVA, Pearson-Korrelation) setzen bestimmte Ei
 
 ### Alle vier auf denselben Datensatz anwenden
 
-[//]: # (<!---FUN testingNormality-->)
+{/*---FUN testingNormality--*/}
 
 ```kotlin
 val sensorReadings = doubleArrayOf(
@@ -45,7 +45,7 @@ dagostino.pValue  // D'Agostino-Pearson
 jarqueBera.pValue // Jarque-Bera
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Wenn die Tests unterschiedliche Ergebnisse liefern, bevorzugen Sie Shapiro-Wilk für kleine bis mittlere Stichproben und Anderson-Darling, wenn das Verhalten in den Rändern relevant ist.
@@ -53,7 +53,7 @@ Wenn die Tests unterschiedliche Ergebnisse liefern, bevorzugen Sie Shapiro-Wilk 
 
 ### Mit deskriptiver Statistik kombinieren
 
-[//]: # (<!---FUN testingNormalityDescriptive-->)
+{/*---FUN testingNormalityDescriptive--*/}
 
 ```kotlin
 val summary = sensorReadings.describe()
@@ -61,7 +61,7 @@ summary.skewness // close to 0 for symmetric data
 summary.kurtosis // close to 0 (excess) for Normal-like tails
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Varianzhomogenität
 
@@ -75,7 +75,7 @@ Beim Vergleich von Gruppen (t-Test, ANOVA) wird häufig Varianzgleichheit voraus
 
 ### Varianzen vor der ANOVA prüfen
 
-[//]: # (<!---FUN testingVarianceHomogeneity-->)
+{/*---FUN testingVarianceHomogeneity--*/}
 
 ```kotlin
 val batchA = doubleArrayOf(48.2, 47.8, 49.1, 48.5, 47.9, 48.7, 48.3, 49.0, 48.1, 48.6)
@@ -91,13 +91,13 @@ bartlett.pValue // Bartlett
 fligner.pValue  // Fligner-Killeen
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Ein hoher p-Wert bei allen drei Tests spricht dafür, mit der ANOVA oder einem t-Test mit gleichen Varianzen fortzufahren.
 
 ### Dann ANOVA durchführen
 
-[//]: # (<!---FUN testingVarianceThenAnova-->)
+{/*---FUN testingVarianceThenAnova--*/}
 
 ```kotlin
 val anova = oneWayAnova(batchA, batchB, batchC)
@@ -105,7 +105,7 @@ anova.fStatistic
 anova.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Anpassungsgüte
 
@@ -113,7 +113,7 @@ anova.pValue
 
 Vergleichen Sie beobachtete Daten mit einer theoretischen Verteilung.
 
-[//]: # (<!---FUN testingKsOneSample-->)
+{/*---FUN testingKsOneSample--*/}
 
 ```kotlin
 val temperatureReadings = doubleArrayOf(
@@ -132,13 +132,13 @@ ks.statistic // smaller means better fit
 ks.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Chi-Quadrat-Anpassungstest
 
 Prüfen Sie, ob beobachtete Kategoriehäufigkeiten den erwarteten Proportionen entsprechen.
 
-[//]: # (<!---FUN testingChiSquared-->)
+{/*---FUN testingChiSquared--*/}
 
 ```kotlin
 // Defect counts across 5 product categories
@@ -154,13 +154,13 @@ val specific = chiSquaredTest(observedDefects, expectedCounts)
 specific.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Zwei-Stichproben-KS-Test
 
 Vergleichen Sie zwei Stichproben, ohne eine bestimmte Verteilung vorauszusetzen.
 
-[//]: # (<!---FUN testingKsTwoSample-->)
+{/*---FUN testingKsTwoSample--*/}
 
 ```kotlin
 val morningReadings = doubleArrayOf(
@@ -174,4 +174,4 @@ val twoSampleKs = kolmogorovSmirnovTest(morningReadings, nightReadings)
 twoSampleKs.pValue // low p-value suggests different underlying distributions
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}

--- a/docs/de/hypothesis/overview.mdx
+++ b/docs/de/hypothesis/overview.mdx
@@ -3,7 +3,7 @@ title: "Hypothesentests"
 description: "t-Tests, ANOVA, Chi-Quadrat, Fisher-Exakttest, Mann-Whitney, Wilcoxon, Normalitätstests und Varianzhomogenitätstests in kstats-hypothesis."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
 
 `kstats-hypothesis` stellt statistische Tests bereit, gegliedert nach der Fragestellung, die sie beantworten. Die meisten Funktionen liefern ein `TestResult` zurück; `oneWayAnova()` gibt ein `AnovaResult` mit der vollständigen ANOVA-Tabelle zurück.
 
@@ -11,7 +11,7 @@ description: "t-Tests, ANOVA, Chi-Quadrat, Fisher-Exakttest, Mann-Whitney, Wilco
 
 Jeder Test erzeugt ein Ergebnis mit einheitlicher Struktur. Die `statistic` ist der berechnete Testwert, der `pValue` gibt die Wahrscheinlichkeit an, unter der Nullhypothese ein mindestens so extremes Ergebnis zu beobachten, und `isSignificant()` vergleicht den p-Wert mit einem Schwellenwert.
 
-[//]: # (<!---FUN hypTestResult-->)
+{/*---FUN hypTestResult--*/}
 
 ```kotlin
 val sample = doubleArrayOf(5.0, 6.0, 7.0, 5.5, 6.5)
@@ -25,7 +25,7 @@ result.isSignificant()   // true (p < 0.05)
 result.confidenceInterval // (5.02, 6.98)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 `isSignificant()` verwendet standardmäßig $\alpha = 0.05$. Ein anderer Schwellenwert kann explizit übergeben werden: `result.isSignificant(alpha = 0.01)`.
@@ -39,7 +39,7 @@ Setzen Sie `alternative` explizit für einseitige Tests. Der Standardwert ist `A
 
 Der Einstichproben-t-Test vergleicht den Mittelwert einer einzelnen Stichprobe mit einem bekannten oder hypothetischen Wert.
 
-[//]: # (<!---FUN hypOneSample-->)
+{/*---FUN hypOneSample--*/}
 
 ```kotlin
 val sample = doubleArrayOf(5.1, 4.9, 5.3, 5.0, 4.8)
@@ -54,7 +54,7 @@ val one = tTest(sample, mu = 5.0, alternative = Alternative.GREATER)
 one.pValue               // one-sided p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Verwenden Sie `Alternative.GREATER` oder `Alternative.LESS` für gerichtete Hypothesen, anstatt einen zweiseitigen p-Wert zu halbieren. Das Konfidenzintervall passt sich entsprechend an.
@@ -66,7 +66,7 @@ Verwenden Sie `Alternative.GREATER` oder `Alternative.LESS` für gerichtete Hypo
 
 Vergleicht die Mittelwerte zweier unabhängiger Stichproben. Welchs t-Test (ungleiche Varianzen) ist die Standardeinstellung.
 
-[//]: # (<!---FUN hypTwoSample-->)
+{/*---FUN hypTwoSample--*/}
 
 ```kotlin
 val group1 = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -78,7 +78,7 @@ result.pValue            // 0.0011
 result.isSignificant()   // true
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Warning>
 `equalVariances` ist standardmäßig `false`, d. h. es wird Welchs t-Test verwendet. Setzen Sie `equalVariances = true` nur, nachdem Sie gleiche Varianzen mit `leveneTest()` oder `bartlettTest()` bestätigt haben.
@@ -88,11 +88,11 @@ result.isSignificant()   // true
 
 Vergleicht zwei zusammenhängende Messungen (vorher/nachher, links/rechts) an denselben Versuchspersonen.
 
-[//]: # (<!---FUN hypPaired-->)
+{/*---FUN hypPaired--*/}
 
 ```kotlin
 val before = doubleArrayOf(200.0, 190.0, 210.0, 180.0, 195.0)
-val after  = doubleArrayOf(190.0, 180.0, 195.0, 170.0, 185.0)
+val after = doubleArrayOf(190.0, 180.0, 195.0, 170.0, 185.0)
 
 val result = pairedTTest(before, after)
 result.statistic         // positive t (before > after)
@@ -100,13 +100,13 @@ result.pValue            // p-value for the difference
 result.isSignificant()   // true if the change is significant
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Mann-Whitney-U-Test
 
 Nichtparametrische Alternative zum Zweistichproben-t-Test. Vergleicht Ränge statt Mittelwerte.
 
-[//]: # (<!---FUN hypMannWhitney-->)
+{/*---FUN hypMannWhitney--*/}
 
 ```kotlin
 val group1 = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -118,24 +118,24 @@ result.pValue            // < 0.02
 result.isSignificant()   // true
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Wilcoxon-Vorzeichen-Rang-Test
 
 Nichtparametrische Alternative zum gepaarten t-Test. Prüft, ob gepaarte Differenzen symmetrisch um Null verteilt sind.
 
-[//]: # (<!---FUN hypWilcoxon-->)
+{/*---FUN hypWilcoxon--*/}
 
 ```kotlin
 val before = doubleArrayOf(10.0, 12.0, 14.0, 16.0, 18.0)
-val after  = doubleArrayOf(8.0, 9.0, 11.0, 12.0, 13.0)
+val after = doubleArrayOf(8.0, 9.0, 11.0, 12.0, 13.0)
 
 val result = wilcoxonSignedRankTest(before, after)
 result.statistic         // W+ = 15.0
 result.pValue            // p-value with continuity correction
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Unterscheiden sich drei oder mehr Gruppen?
 
@@ -143,7 +143,7 @@ result.pValue            // p-value with continuity correction
 
 Prüft, ob sich die Mittelwerte von drei oder mehr Gruppen unterscheiden. Gibt ein `AnovaResult` mit der vollständigen ANOVA-Tabelle zurück.
 
-[//]: # (<!---FUN hypAnova-->)
+{/*---FUN hypAnova--*/}
 
 ```kotlin
 val g1 = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -161,7 +161,7 @@ anova.msBetween          // 125.0
 anova.msWithin           // 2.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 Die ANOVA setzt Normalverteilung innerhalb jeder Gruppe und gleiche Varianzen über alle Gruppen voraus. Prüfen Sie die Normalverteilung mit `shapiroWilkTest()` und die Varianzhomogenität mit `leveneTest()` oder `bartlettTest()`, bevor Sie eine ANOVA durchführen.
@@ -171,7 +171,7 @@ Die ANOVA setzt Normalverteilung innerhalb jeder Gruppe und gleiche Varianzen ü
 
 Nichtparametrische Alternative zur ANOVA mit Messwiederholung. Vergleicht Ränge über verbundene Gruppen.
 
-[//]: # (<!---FUN hypFriedman-->)
+{/*---FUN hypFriedman--*/}
 
 ```kotlin
 val treatment1 = doubleArrayOf(5.0, 6.0, 7.0, 5.5, 6.5)
@@ -183,13 +183,13 @@ result.statistic         // Friedman chi-squared
 result.pValue            // p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Sind meine Daten normalverteilt?
 
 Vier Normalitätstests stehen zur Verfügung. Jeder gibt ein `TestResult` zurück — ein signifikantes Ergebnis (niedriger p-Wert) deutet auf Abweichungen von der Normalverteilung hin.
 
-[//]: # (<!---FUN hypNormality-->)
+{/*---FUN hypNormality--*/}
 
 ```kotlin
 val sample = doubleArrayOf(
@@ -203,7 +203,7 @@ dagostinoPearsonTest(sample).pValue  // combines skewness and kurtosis tests
 jarqueBeraTest(sample).pValue        // asymptotic test based on skewness and kurtosis
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Der Shapiro-Wilk-Test ist die gebräuchlichste Wahl und in der Regel der stärkste Test für kleine bis mittlere Stichproben (n &lt; 5000). Der Anderson-Darling-Test ist empfindlicher gegenüber Abweichungen in den Verteilungsrändern. D'Agostino-Pearson und Jarque-Bera sind schneller bei großen Stichproben.
@@ -215,7 +215,7 @@ Der Shapiro-Wilk-Test ist die gebräuchlichste Wahl und in der Regel der stärks
 
 Prüft, ob beobachtete Häufigkeiten den erwarteten Häufigkeiten entsprechen.
 
-[//]: # (<!---FUN hypChiSquared-->)
+{/*---FUN hypChiSquared--*/}
 
 ```kotlin
 val observed = intArrayOf(50, 30, 20)
@@ -227,13 +227,13 @@ result.pValue            // 0.0821
 result.isSignificant()   // false at α = 0.05
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### G-Test
 
 Likelihood-Ratio-Alternative zum Chi-Quadrat-Test. Oft bevorzugt bei kleinen erwarteten Häufigkeiten.
 
-[//]: # (<!---FUN hypGTest-->)
+{/*---FUN hypGTest--*/}
 
 ```kotlin
 val observed = intArrayOf(50, 30, 20)
@@ -244,13 +244,13 @@ result.statistic         // G statistic
 result.pValue            // p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Binomialtest
 
 Prüft, ob der beobachtete Anteil an Erfolgen einer hypothetischen Wahrscheinlichkeit entspricht.
 
-[//]: # (<!---FUN hypBinomial-->)
+{/*---FUN hypBinomial--*/}
 
 ```kotlin
 val result = binomialTest(successes = 60, trials = 100, probability = 0.5)
@@ -258,13 +258,13 @@ result.pValue            // p-value for H₀: p = 0.5
 result.isSignificant()   // true if 60/100 is significantly different from 0.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Fisher-Exakttest
 
 Exakter Test für 2x2-Kontingenztafeln. Dem Chi-Quadrat-Test bei kleinen Stichproben vorzuziehen.
 
-[//]: # (<!---FUN hypFisher-->)
+{/*---FUN hypFisher--*/}
 
 ```kotlin
 // 2×2 table: [[10, 30], [20, 40]]
@@ -273,7 +273,7 @@ result.pValue            // exact p-value
 result.isSignificant()   // true or false
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Warning>
 Der Fisher-Exakttest ist für kleine Kontingenztafeln konzipiert. Für größere Tabellen verwenden Sie `chiSquaredTest()` mit einem Chi-Quadrat-Unabhängigkeitstest.
@@ -283,7 +283,7 @@ Der Fisher-Exakttest ist für kleine Kontingenztafeln konzipiert. Für größere
 
 Varianzhomogenität ist eine Voraussetzung der ANOVA und einiger t-Test-Varianten. Drei Tests stehen zur Verfügung:
 
-[//]: # (<!---FUN hypVarianceHomogeneity-->)
+{/*---FUN hypVarianceHomogeneity--*/}
 
 ```kotlin
 val g1 = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -295,7 +295,7 @@ bartlettTest(g1, g2, g3).pValue       // most powerful when normality holds
 flignerKilleenTest(g1, g2, g3).pValue // rank-based, robust to outliers
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Der Levene-Test ist die sicherste Standardwahl — er ist robust gegenüber Abweichungen von der Normalverteilung. Verwenden Sie den Bartlett-Test nur, wenn die Daten innerhalb jeder Gruppe annähernd normalverteilt sind (Bartlett ist in diesem Fall leistungsfähiger). Der Fligner-Killeen-Test ist am robustesten gegenüber Ausreißern.
@@ -307,7 +307,7 @@ Der Levene-Test ist die sicherste Standardwahl — er ist robust gegenüber Abwe
 
 Der Zweistichproben-KS-Test prüft, ob zwei Stichproben aus derselben stetigen Verteilung stammen.
 
-[//]: # (<!---FUN hypKolmogorovSmirnov-->)
+{/*---FUN hypKolmogorovSmirnov--*/}
 
 ```kotlin
 val sample1 = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -318,7 +318,7 @@ result.statistic         // D = max difference between ECDFs
 result.pValue            // p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Die Alternative-Aufzählung
 

--- a/docs/de/sampling/overview.mdx
+++ b/docs/de/sampling/overview.mdx
@@ -3,7 +3,7 @@ title: "Sampling & Transformation"
 description: "Rangbildung, z-Score-Normalisierung, Min-Max-Skalierung, Binning, Häufigkeitstabellen, Bootstrap, Zufallsstichproben und gewichteter Würfel in kstats-sampling."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.sampling.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.sampling.samples.DocsSamples--*/}
 
 `kstats-sampling` stellt Vorverarbeitungs- und Resampling-Werkzeuge bereit, die am Rand eines Analyse-Workflows stehen. Das Modul deckt zwei Bereiche ab: die Transformation numerischer Daten und das Ziehen von Zufallsstichproben.
 
@@ -13,7 +13,7 @@ description: "Rangbildung, z-Score-Normalisierung, Min-Max-Skalierung, Binning, 
 
 `rank()` ersetzt numerische Werte durch ihre geordneten Positionen. Die Behandlung von Bindungen wird über den Parameter `TieMethod` gesteuert.
 
-[//]: # (<!---FUN sampRanking-->)
+{/*---FUN sampRanking--*/}
 
 ```kotlin
 val data = doubleArrayOf(3.0, 1.0, 4.0, 1.0, 5.0)
@@ -27,7 +27,7 @@ data.rank(TieMethod.ORDINAL)       // [3.0, 1.0, 4.0, 2.0, 5.0]
 data.percentileRank()              // ranks scaled to 0-100
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 `TieMethod`-Optionen:
@@ -42,7 +42,7 @@ data.percentileRank()              // ranks scaled to 0-100
 
 Zwei gängige Skalierungsverfahren: z-Score-Standardisierung (Mittelwert 0, Standardabweichung 1) und Min-Max-Skalierung.
 
-[//]: # (<!---FUN sampNormalization-->)
+{/*---FUN sampNormalization--*/}
 
 ```kotlin
 val data = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -53,7 +53,7 @@ data.minMaxNormalize()             // [0.0, 0.25, 0.5, 0.75, 1.0]
 data.minMaxNormalize(0.0, 100.0)   // [0.0, 25.0, 50.0, 75.0, 100.0]
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 `zScore()` ist geeignet, wenn die nachfolgende Methode standardisierte Eingaben voraussetzt. `minMaxNormalize()` skaliert standardmäßig auf [0, 1] oder auf einen benutzerdefinierten Bereich.
 
@@ -71,7 +71,7 @@ $$
 
 `bin()` gruppiert Werte in gleich breite Intervalle und gibt die Elemente jedes Bins zurück. `frequencyTable()` liefert Intervallgrenzen, Häufigkeiten, relative Häufigkeiten und kumulative Häufigkeiten.
 
-[//]: # (<!---FUN sampBinning-->)
+{/*---FUN sampBinning--*/}
 
 ```kotlin
 val data = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
@@ -93,7 +93,7 @@ freq[0].relativeFrequency          // proportion of total
 freq[0].cumulativeFrequency        // running total of relative frequencies
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 `bin()` gibt die tatsächlichen Elemente zurück, die in jedes Intervall fallen — nützlich für die Weiterverarbeitung. `frequencyTable()` liefert zusammenfassende Statistiken pro Bin — nützlich für histogrammartige Berichte.
 
@@ -107,7 +107,7 @@ Sowohl `bin()` als auch `frequencyTable()` akzeptieren entweder eine **Bin-Anzah
 
 `randomSample()` zieht ohne Zurücklegen. `bootstrapSample()` zieht mit Zurücklegen — dasselbe Element kann mehrfach vorkommen.
 
-[//]: # (<!---FUN sampRandomBootstrap-->)
+{/*---FUN sampRandomBootstrap--*/}
 
 ```kotlin
 val items = listOf("A", "B", "C", "D", "E")
@@ -116,7 +116,7 @@ items.randomSample(3, Random(42))     // 3 distinct items
 items.bootstrapSample(6, Random(42))  // 6 items, may have repeats
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 `randomSample()` zieht **ohne Zurücklegen** — jedes Element kommt höchstens einmal vor. Die Stichprobengröße darf die Größe der Sammlung nicht überschreiten.
@@ -128,7 +128,7 @@ items.bootstrapSample(6, Random(42))  // 6 items, may have repeats
 
 `WeightedCoin` simuliert einen verzerrten Münzwurf. `WeightedDice` simuliert eine gewichtete Zufallsauswahl aus einer Menge von Ergebnissen.
 
-[//]: # (<!---FUN sampWeightedRandom-->)
+{/*---FUN sampWeightedRandom--*/}
 
 ```kotlin
 val coin = WeightedCoin(probability = 0.7)
@@ -138,7 +138,7 @@ val dice = WeightedDice(mapOf("A" to 3.0, "B" to 1.0))
 dice.roll()                        // "A" with 75% probability, "B" with 25%
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Die Gewichte müssen sich nicht zu 1 summieren — sie werden intern normalisiert. `WeightedDice` funktioniert mit jedem Typ als Ergebnis.
 

--- a/docs/distributions/overview.mdx
+++ b/docs/distributions/overview.mdx
@@ -3,13 +3,13 @@ title: "Probability Distributions"
 description: "18 continuous and 10 discrete probability distributions with a shared API for density, CDF, quantiles, and sampling in kstats-distributions."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.distributions.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.distributions.samples.DocsSamples--*/}
 
 `kstats-distributions` provides a unified API for continuous and discrete probability models. Every distribution supports the same workflow: construct with parameters, inspect statistical properties, evaluate probabilities, compute quantiles, and draw random samples.
 
 ## Working with a Distribution
 
-[//]: # (<!---FUN distWorkingWithDistribution-->)
+{/*---FUN distWorkingWithDistribution--*/}
 
 ```kotlin
 val normal = NormalDistribution(mu = 0.0, sigma = 1.0)
@@ -35,7 +35,7 @@ normal.sample(Random(42))           // single random draw
 normal.sample(5, Random(42))        // 5 random draws
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Shared API
 
@@ -67,7 +67,7 @@ Constructors validate parameters eagerly. Invalid values (negative standard devi
 
         **Parameters:** `mu` — mean, `sigma` — standard deviation (must be positive)
 
-[//]: # (<!---FUN distNormal-->)
+{/*---FUN distNormal--*/}
 
 ```kotlin
 val d = NormalDistribution(mu = 100.0, sigma = 15.0)
@@ -76,7 +76,7 @@ d.cdf(115.0) // 0.8413
 d.quantile(0.975) // 129.3994
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use when data is approximately symmetric and unbounded.
       </Accordion>
@@ -86,7 +86,7 @@ d.quantile(0.975) // 129.3994
 
         **Parameters:** `df` — degrees of freedom (must be positive)
 
-[//]: # (<!---FUN distStudentT-->)
+{/*---FUN distStudentT--*/}
 
 ```kotlin
 val d = StudentTDistribution(degreesOfFreedom = 10.0)
@@ -95,7 +95,7 @@ d.cdf(2.228) // ≈ 0.975
 d.quantile(0.975) // 2.2281
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for confidence intervals and t-tests when the sample size is small.
       </Accordion>
@@ -105,7 +105,7 @@ d.quantile(0.975) // 2.2281
 
         **Parameters:** `location` — center, `scale` — spread parameter (must be positive)
 
-[//]: # (<!---FUN distLogistic-->)
+{/*---FUN distLogistic--*/}
 
 ```kotlin
 val d = LogisticDistribution(mu = 0.0, scale = 1.0)
@@ -114,7 +114,7 @@ d.cdf(0.0)   // 0.5
 d.pdf(0.0)   // 0.25
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use when a closed-form CDF is needed or data has slightly heavier tails than normal.
       </Accordion>
@@ -124,7 +124,7 @@ d.pdf(0.0)   // 0.25
 
         **Parameters:** `location` — center (median), `scale` — half-width at half-maximum (must be positive)
 
-[//]: # (<!---FUN distCauchy-->)
+{/*---FUN distCauchy--*/}
 
 ```kotlin
 val d = CauchyDistribution(location = 0.0, scale = 1.0)
@@ -133,7 +133,7 @@ d.cdf(0.0)        // 0.5
 d.quantile(0.75)  // 1.0
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for data with extreme outliers where the mean is not a meaningful summary.
       </Accordion>
@@ -143,7 +143,7 @@ d.quantile(0.75)  // 1.0
 
         **Parameters:** `location` — center (mean and median), `scale` — spread parameter (must be positive)
 
-[//]: # (<!---FUN distLaplace-->)
+{/*---FUN distLaplace--*/}
 
 ```kotlin
 val d = LaplaceDistribution(mu = 0.0, scale = 1.0)
@@ -152,7 +152,7 @@ d.variance   // 2.0
 d.pdf(0.0)   // 0.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for data with a sharp peak at the center and exponential tails.
       </Accordion>
@@ -166,7 +166,7 @@ d.pdf(0.0)   // 0.5
 
         **Parameters:** `rate` — event rate, the reciprocal of the mean (must be positive)
 
-[//]: # (<!---FUN distExponential-->)
+{/*---FUN distExponential--*/}
 
 ```kotlin
 val d = ExponentialDistribution(rate = 2.0)
@@ -175,7 +175,7 @@ d.cdf(1.0)   // 0.8647
 d.quantile(0.5) // 0.3466
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for waiting times, durations, and inter-arrival times.
       </Accordion>
@@ -185,7 +185,7 @@ d.quantile(0.5) // 0.3466
 
         **Parameters:** `shape` — shape parameter $k$ (must be positive), `scale` — scale parameter $\theta$ (must be positive)
 
-[//]: # (<!---FUN distGamma-->)
+{/*---FUN distGamma--*/}
 
 ```kotlin
 val d = GammaDistribution(shape = 2.0, rate = 0.5)
@@ -194,7 +194,7 @@ d.variance   // 8.0
 d.cdf(4.0)   // 0.5940
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for positive continuous data with right skew, such as aggregate waiting times or rainfall amounts.
       </Accordion>
@@ -204,7 +204,7 @@ d.cdf(4.0)   // 0.5940
 
         **Parameters:** `shape` — shape $k$ (must be positive), `scale` — scale $\lambda$ (must be positive)
 
-[//]: # (<!---FUN distWeibull-->)
+{/*---FUN distWeibull--*/}
 
 ```kotlin
 val d = WeibullDistribution(shape = 1.5, scale = 1.0)
@@ -212,7 +212,7 @@ d.mean       // 0.9027
 d.cdf(1.0)   // 0.6321
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for time-to-failure data, wind speed modeling, and survival analysis.
       </Accordion>
@@ -222,7 +222,7 @@ d.cdf(1.0)   // 0.6321
 
         **Parameters:** `mu` — mean of the log, `sigma` — standard deviation of the log (must be positive)
 
-[//]: # (<!---FUN distLogNormal-->)
+{/*---FUN distLogNormal--*/}
 
 ```kotlin
 val d = LogNormalDistribution(mu = 0.0, sigma = 1.0)
@@ -231,7 +231,7 @@ d.quantile(0.5) // 1.0
 d.cdf(1.0)      // 0.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for multiplicative processes: stock prices, biological measurements, file sizes.
       </Accordion>
@@ -241,7 +241,7 @@ d.cdf(1.0)      // 0.5
 
         **Parameters:** `shape` — shape $m \ge 0.5$, `spread` — spread $\Omega$ (must be positive)
 
-[//]: # (<!---FUN distNakagami-->)
+{/*---FUN distNakagami--*/}
 
 ```kotlin
 val d = NakagamiDistribution(mu = 1.0, omega = 1.0)
@@ -249,7 +249,7 @@ d.mean       // 0.8862
 d.variance   // 0.2146
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for signal envelope modeling in fading channels.
       </Accordion>
@@ -259,7 +259,7 @@ d.variance   // 0.2146
 
         **Parameters:** `location` — shift parameter, `scale` — scale parameter (must be positive)
 
-[//]: # (<!---FUN distLevy-->)
+{/*---FUN distLevy--*/}
 
 ```kotlin
 val d = LevyDistribution(mu = 0.0, c = 1.0)
@@ -267,7 +267,7 @@ d.cdf(1.0)   // 0.3173
 d.sf(1.0)    // 0.6827
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for extreme-value modeling with very heavy right tails.
       </Accordion>
@@ -281,7 +281,7 @@ d.sf(1.0)    // 0.6827
 
         **Parameters:** `alpha` — shape $\alpha$ (must be positive), `beta` — shape $\beta$ (must be positive)
 
-[//]: # (<!---FUN distBeta-->)
+{/*---FUN distBeta--*/}
 
 ```kotlin
 val d = BetaDistribution(alpha = 2.0, beta = 5.0)
@@ -290,7 +290,7 @@ d.cdf(0.3)   // 0.5798
 d.pdf(0.2)   // 2.4576
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for proportions, probabilities, and bounded data on [0, 1].
       </Accordion>
@@ -300,7 +300,7 @@ d.pdf(0.2)   // 2.4576
 
         **Parameters:** `a` — lower bound, `b` — upper bound (must satisfy `a < b`)
 
-[//]: # (<!---FUN distUniform-->)
+{/*---FUN distUniform--*/}
 
 ```kotlin
 val d = UniformDistribution(min = 0.0, max = 10.0)
@@ -309,7 +309,7 @@ d.variance   // 8.3333
 d.cdf(3.0)   // 0.3
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use when all values in a range are equally likely.
       </Accordion>
@@ -319,7 +319,7 @@ d.cdf(3.0)   // 0.3
 
         **Parameters:** `a` — minimum, `b` — maximum, `c` — mode (must satisfy `a ≤ c ≤ b`)
 
-[//]: # (<!---FUN distTriangular-->)
+{/*---FUN distTriangular--*/}
 
 ```kotlin
 val d = TriangularDistribution(a = 0.0, b = 10.0, c = 3.0)
@@ -327,7 +327,7 @@ d.mean       // 4.3333
 d.cdf(3.0)   // 0.3
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for rough estimates when only the minimum, maximum, and most likely value are known.
       </Accordion>
@@ -341,7 +341,7 @@ d.cdf(3.0)   // 0.3
 
         **Parameters:** `xm` — minimum value (scale, must be positive), `alpha` — shape (tail index, must be positive)
 
-[//]: # (<!---FUN distPareto-->)
+{/*---FUN distPareto--*/}
 
 ```kotlin
 val d = ParetoDistribution(shape = 2.0, scale = 1.0)
@@ -349,7 +349,7 @@ d.mean       // 2.0
 d.cdf(2.0)   // 0.75
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for wealth distributions, city populations, and file sizes.
       </Accordion>
@@ -359,7 +359,7 @@ d.cdf(2.0)   // 0.75
 
         **Parameters:** `location` — mode, `scale` — spread (must be positive)
 
-[//]: # (<!---FUN distGumbel-->)
+{/*---FUN distGumbel--*/}
 
 ```kotlin
 val d = GumbelDistribution(mu = 0.0, beta = 1.0)
@@ -367,7 +367,7 @@ d.mean       // 0.5772
 d.cdf(0.0)   // 0.3679
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for extreme-value analysis: maximum temperatures, flood levels, structural loads.
       </Accordion>
@@ -377,7 +377,7 @@ d.cdf(0.0)   // 0.3679
 
         **Parameters:** `df` — degrees of freedom (must be positive)
 
-[//]: # (<!---FUN distChiSquared-->)
+{/*---FUN distChiSquared--*/}
 
 ```kotlin
 val d = ChiSquaredDistribution(degreesOfFreedom = 5.0)
@@ -386,7 +386,7 @@ d.variance   // 10.0
 d.cdf(11.07) // ≈ 0.95
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use internally by chi-squared tests or for direct variance inference.
       </Accordion>
@@ -396,7 +396,7 @@ d.cdf(11.07) // ≈ 0.95
 
         **Parameters:** `df1` — numerator degrees of freedom (must be positive), `df2` — denominator degrees of freedom (must be positive)
 
-[//]: # (<!---FUN distF-->)
+{/*---FUN distF--*/}
 
 ```kotlin
 val d = FDistribution(dfNumerator = 5.0, dfDenominator = 10.0)
@@ -404,7 +404,7 @@ d.mean       // 1.25
 d.cdf(3.33)  // ≈ 0.95
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use internally by ANOVA and F-tests.
       </Accordion>
@@ -422,7 +422,7 @@ d.cdf(3.33)  // ≈ 0.95
 
         **Parameters:** `lambda` — expected number of events (must be positive)
 
-[//]: # (<!---FUN distPoisson-->)
+{/*---FUN distPoisson--*/}
 
 ```kotlin
 val d = PoissonDistribution(rate = 3.0)
@@ -432,7 +432,7 @@ d.cdf(5)        // 0.9161
 d.quantileInt(0.95) // 6
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for count data: defects per batch, arrivals per hour, events per day.
       </Accordion>
@@ -442,7 +442,7 @@ d.quantileInt(0.95) // 6
 
         **Parameters:** `trials` — number of trials (must be non-negative), `probability` — success probability per trial (must be in [0, 1])
 
-[//]: # (<!---FUN distBinomial-->)
+{/*---FUN distBinomial--*/}
 
 ```kotlin
 val d = BinomialDistribution(trials = 10, probability = 0.3)
@@ -452,7 +452,7 @@ d.cdf(3)        // 0.6496
 d.quantileInt(0.5) // 3
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for yes/no experiments repeated a known number of times.
       </Accordion>
@@ -462,7 +462,7 @@ d.quantileInt(0.5) // 3
 
         **Parameters:** `r` — number of successes (must be positive), `p` — success probability (must be in (0, 1])
 
-[//]: # (<!---FUN distNegativeBinomial-->)
+{/*---FUN distNegativeBinomial--*/}
 
 ```kotlin
 val d = NegativeBinomialDistribution(successes = 5, probability = 0.5)
@@ -471,7 +471,7 @@ d.variance      // 10.0
 d.pmf(3)        // probability of exactly 3 failures before 5 successes
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for over-dispersed count data or modeling the number of trials until a target is reached.
       </Accordion>
@@ -481,7 +481,7 @@ d.pmf(3)        // probability of exactly 3 failures before 5 successes
 
         **Parameters:** `probability` — success probability per trial (must be in (0, 1])
 
-[//]: # (<!---FUN distGeometric-->)
+{/*---FUN distGeometric--*/}
 
 ```kotlin
 val d = GeometricDistribution(probability = 0.3)
@@ -490,7 +490,7 @@ d.pmf(1)        // 0.3
 d.cdf(3)        // 0.657
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for "how many tries until it works" questions.
       </Accordion>
@@ -504,7 +504,7 @@ d.cdf(3)        // 0.657
 
         **Parameters:** `populationSize` — total population, `successStates` — number of success items, `trials` — number of draws
 
-[//]: # (<!---FUN distHypergeometric-->)
+{/*---FUN distHypergeometric--*/}
 
 ```kotlin
 val d = HypergeometricDistribution(population = 50, successes = 10, draws = 5)
@@ -512,7 +512,7 @@ d.mean          // 1.0
 d.pmf(2)        // probability of exactly 2 successes in 5 draws
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use when sampling without replacement matters: quality control, card games, lottery problems.
       </Accordion>
@@ -522,7 +522,7 @@ d.pmf(2)        // probability of exactly 2 successes in 5 draws
 
         **Parameters:** `trials` — number of trials, `alpha` — Beta shape parameter, `beta` — Beta shape parameter
 
-[//]: # (<!---FUN distBetaBinomial-->)
+{/*---FUN distBetaBinomial--*/}
 
 ```kotlin
 val d = BetaBinomialDistribution(trials = 10, alpha = 2.0, beta = 3.0)
@@ -530,7 +530,7 @@ d.mean          // 4.0
 d.pmf(4)        // probability of exactly 4 successes
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for over-dispersed binomial data where the success probability varies.
       </Accordion>
@@ -544,7 +544,7 @@ d.pmf(4)        // probability of exactly 4 successes
 
         **Parameters:** `probability` — success probability (must be in [0, 1])
 
-[//]: # (<!---FUN distBernoulli-->)
+{/*---FUN distBernoulli--*/}
 
 ```kotlin
 val d = BernoulliDistribution(probability = 0.7)
@@ -553,7 +553,7 @@ d.pmf(1)        // 0.7
 d.pmf(0)        // 0.3
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for coin-flip–like binary outcomes.
       </Accordion>
@@ -563,7 +563,7 @@ d.pmf(0)        // 0.3
 
         **Parameters:** `a` — lower bound, `b` — upper bound (must satisfy `a ≤ b`)
 
-[//]: # (<!---FUN distUniformDiscrete-->)
+{/*---FUN distUniformDiscrete--*/}
 
 ```kotlin
 val d = UniformDiscreteDistribution(min = 1, max = 6)
@@ -572,7 +572,7 @@ d.pmf(3)        // 0.1667
 d.cdf(3)        // 0.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for fair dice, uniform random integer selection.
       </Accordion>
@@ -586,7 +586,7 @@ d.cdf(3)        // 0.5
 
         **Parameters:** `n` — number of elements (must be positive), `s` — exponent (must be positive)
 
-[//]: # (<!---FUN distZipf-->)
+{/*---FUN distZipf--*/}
 
 ```kotlin
 val d = ZipfDistribution(numberOfElements = 100, exponent = 1.0)
@@ -594,7 +594,7 @@ d.pmf(1)        // probability of rank 1 (the most common)
 d.pmf(100)      // probability of rank 100 (the least common)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for word frequencies, city sizes, and website traffic distributions.
       </Accordion>
@@ -604,7 +604,7 @@ d.pmf(100)      // probability of rank 100 (the least common)
 
         **Parameters:** `p` — parameter in (0, 1)
 
-[//]: # (<!---FUN distLogarithmic-->)
+{/*---FUN distLogarithmic--*/}
 
 ```kotlin
 val d = LogarithmicDistribution(probability = 0.5)
@@ -613,7 +613,7 @@ d.pmf(1)        // 0.7213
 d.pmf(2)        // 0.1803
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
         Use for species abundance data and similar long-tailed count distributions.
       </Accordion>

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -3,11 +3,11 @@ title: "Introduction"
 description: "kstats is a Kotlin Multiplatform statistics library covering descriptive stats, distributions, hypothesis tests, correlation, and sampling."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
 
 kstats is a Kotlin Multiplatform statistics library. It covers descriptive statistics, probability distributions, hypothesis testing, correlation and regression, and sampling — everything needed for quantitative analysis in Kotlin.
 
-[//]: # (<!---FUN introOverview-->)
+{/*---FUN introOverview--*/}
 
 ```kotlin
 val sample = doubleArrayOf(2.0, 4.0, 4.0, 5.0, 7.0, 9.0)
@@ -23,7 +23,7 @@ val fitted = NormalDistribution(mu = summary.mean, sigma = summary.standardDevia
 fitted.cdf(6.0)           // 0.6335
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Modules
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -3,15 +3,15 @@ title: "Quickstart"
 description: "Compute descriptive statistics, fit a distribution, run a hypothesis test, and measure correlation in five minutes."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.samples.DocsSamples--*/}
 
-[//]: # (<!---IMPORT org.oremif.kstats.distributions.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.distributions.samples.DocsSamples--*/}
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
 
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.correlation.samples.DocsSamples--*/}
 
-[//]: # (<!---IMPORT org.oremif.kstats.sampling.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.sampling.samples.DocsSamples--*/}
 
 Start with the end-to-end scenario below, or jump to the per-module snippets at the bottom.
 
@@ -19,17 +19,17 @@ Start with the end-to-end scenario below, or jump to the per-module snippets at 
 
 ### Define a sample
 
-[//]: # (<!---FUN quickstartDefine-->)
+{/*---FUN quickstartDefine--*/}
 
 ```kotlin
 val sample = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Summarize
 
-[//]: # (<!---FUN quickstartSummarize-->)
+{/*---FUN quickstartSummarize--*/}
 
 ```kotlin
 val stats = sample.describe()
@@ -40,13 +40,13 @@ stats.skewness          // 0.6563
 stats.interquartileRange // 1.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 `describe()` returns count, center, spread, quartiles, shape, and standard error in a single object.
 
 ### Check normality
 
-[//]: # (<!---FUN quickstartNormality-->)
+{/*---FUN quickstartNormality--*/}
 
 ```kotlin
 val normality = shapiroWilkTest(sample)
@@ -55,11 +55,11 @@ normality.pValue             // > 0.05 → no evidence against normality
 normality.isSignificant()    // false
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Fit a distribution
 
-[//]: # (<!---FUN quickstartFit-->)
+{/*---FUN quickstartFit--*/}
 
 ```kotlin
 val normal = NormalDistribution(mu = stats.mean, sigma = stats.standardDeviation)
@@ -67,11 +67,11 @@ normal.cdf(6.0)          // probability that X ≤ 6.0
 normal.quantile(0.95)    // value below which 95% of the distribution falls
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Test a hypothesis
 
-[//]: # (<!---FUN quickstartHypothesis-->)
+{/*---FUN quickstartHypothesis--*/}
 
 ```kotlin
 val result = tTest(sample, mu = 5.0)
@@ -81,11 +81,11 @@ result.isSignificant()   // false — cannot reject H₀: μ = 5.0
 result.confidenceInterval // (3.21, 6.79)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Measure association
 
-[//]: # (<!---FUN quickstartAssociation-->)
+{/*---FUN quickstartAssociation--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -101,14 +101,14 @@ model.rSquared           // 0.9973
 model.predict(6.0)       // 11.99
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Per-Module Snippets
 
 <Tabs>
   <Tab title="Core">
 
-[//]: # (<!---FUN quickstartTabCore-->)
+{/*---FUN quickstartTabCore--*/}
 
 ```kotlin
 val data = doubleArrayOf(2.0, 4.0, 4.0, 5.0, 7.0, 9.0)
@@ -119,11 +119,11 @@ val summary = data.describe()
 summary.skewness          // 0.3942
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
   </Tab>
   <Tab title="Distributions">
 
-[//]: # (<!---FUN quickstartTabDistributions-->)
+{/*---FUN quickstartTabDistributions--*/}
 
 ```kotlin
 val normal = NormalDistribution(mu = 0.0, sigma = 1.0)
@@ -136,11 +136,11 @@ poisson.pmf(5)            // 0.1008
 poisson.cdf(5)            // 0.9161
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
   </Tab>
   <Tab title="Hypothesis">
 
-[//]: # (<!---FUN quickstartTabHypothesis-->)
+{/*---FUN quickstartTabHypothesis--*/}
 
 ```kotlin
 val sample = doubleArrayOf(5.1, 4.9, 5.3, 5.0, 4.8)
@@ -151,11 +151,11 @@ result.isSignificant()    // true or false at α = 0.05
 result.confidenceInterval // one-sided CI
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
   </Tab>
   <Tab title="Correlation">
 
-[//]: # (<!---FUN quickstartTabCorrelation-->)
+{/*---FUN quickstartTabCorrelation--*/}
 
 ```kotlin
 val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -165,11 +165,11 @@ pearsonCorrelation(x, y).coefficient  // 0.9987
 simpleLinearRegression(x, y).slope    // 1.99
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
   </Tab>
   <Tab title="Sampling">
 
-[//]: # (<!---FUN quickstartTabSampling-->)
+{/*---FUN quickstartTabSampling--*/}
 
 ```kotlin
 val data = doubleArrayOf(3.0, 1.0, 4.0, 1.0, 5.0)
@@ -178,7 +178,7 @@ data.zScore()             // [-0.16, -1.47, 0.49, -1.47, 1.14]
 data.minMaxNormalize()    // [0.5, 0.0, 0.75, 0.0, 1.0]
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
   </Tab>
 </Tabs>
 

--- a/docs/guides/how-to/ab-testing.mdx
+++ b/docs/guides/how-to/ab-testing.mdx
@@ -3,8 +3,8 @@ title: "A/B Testing — Compare Variants with Statistical Tests"
 description: "Run a complete A/B test workflow in Kotlin: summarize groups, check assumptions, choose the right test, measure effect size, and correct for multiple comparisons with kstats."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.correlation.samples.DocsSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/ab-testing.ipynb">
   Try this guide as a Kotlin Notebook with Kandy visualizations — run the cells to see charts and explore the data interactively.
@@ -15,7 +15,7 @@ This guide walks through an A/B test comparing two checkout flow variants in a m
 
 ## Experiment Data
 
-[//]: # (<!---FUN abTestingData-->)
+{/*---FUN abTestingData--*/}
 
 ```kotlin
 // Variant A (control): original checkout flow
@@ -31,11 +31,11 @@ val treatmentDurationSec = doubleArrayOf(
 )
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Step 1: Summarize Both Groups
 
-[//]: # (<!---FUN abTestingSummarize-->)
+{/*---FUN abTestingSummarize--*/}
 
 ```kotlin
 val controlSummary = controlDurationSec.describe()
@@ -47,13 +47,13 @@ controlSummary.standardDeviation   // control spread
 treatmentSummary.standardDeviation // treatment spread
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Step 2: Check Assumptions
 
 ### Normality
 
-[//]: # (<!---FUN abTestingNormality-->)
+{/*---FUN abTestingNormality--*/}
 
 ```kotlin
 val controlNormality = shapiroWilkTest(controlDurationSec)
@@ -63,25 +63,25 @@ controlNormality.pValue
 treatmentNormality.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Variance homogeneity
 
-[//]: # (<!---FUN abTestingVariance-->)
+{/*---FUN abTestingVariance--*/}
 
 ```kotlin
 val variances = leveneTest(controlDurationSec, treatmentDurationSec)
 variances.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Step 3: Choose and Run the Test
 
 <Tabs>
 <Tab title="Parametric (normal data)">
 
-[//]: # (<!---FUN abTestingTTest-->)
+{/*---FUN abTestingTTest--*/}
 
 ```kotlin
 // Welch's t-test (default: equalVariances = false)
@@ -93,11 +93,11 @@ result.confidenceInterval // 95% CI for the difference in means
 result.isSignificant()    // true if p < 0.05
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 If the Levene test confirmed equal variances:
 
-[//]: # (<!---FUN abTestingTTestEqual-->)
+{/*---FUN abTestingTTestEqual--*/}
 
 ```kotlin
 val equalVar = tTest(
@@ -108,12 +108,12 @@ val equalVar = tTest(
 equalVar.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 <Tab title="Non-parametric (non-normal data)">
 
-[//]: # (<!---FUN abTestingMannWhitney-->)
+{/*---FUN abTestingMannWhitney--*/}
 
 ```kotlin
 val result = mannWhitneyUTest(controlDurationSec, treatmentDurationSec)
@@ -123,7 +123,7 @@ result.pValue
 result.isSignificant()
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 </Tabs>
@@ -132,7 +132,7 @@ result.isSignificant()
 
 A <Tooltip tip="Standardized measure of the magnitude of a difference, independent of sample size">p-value</Tooltip> tells you *whether* a difference exists; effect size tells you *how large* it is. Cohen's d expresses the difference in standard-deviation units: |d| < 0.2 negligible, 0.2 small, 0.5 medium, 0.8+ large.
 
-[//]: # (<!---FUN abTestingEffectSize-->)
+{/*---FUN abTestingEffectSize--*/}
 
 ```kotlin
 // Cohen's d: how large is the difference in standard-deviation units?
@@ -140,13 +140,13 @@ val d = cohensD(controlDurationSec, treatmentDurationSec)
 d // ~2.9 → large effect (|d| ≥ 0.8)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### One-sided tests
 
 When you expect the treatment to reduce session duration:
 
-[//]: # (<!---FUN abTestingOneSided-->)
+{/*---FUN abTestingOneSided--*/}
 
 ```kotlin
 val oneSided = tTest(
@@ -157,13 +157,13 @@ val oneSided = tTest(
 oneSided.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Step 4: Test a Second Metric
 
 Apply the same workflow to the secondary metric.
 
-[//]: # (<!---FUN abTestingSecondMetric-->)
+{/*---FUN abTestingSecondMetric--*/}
 
 ```kotlin
 // Number of completed checkout steps per session
@@ -184,13 +184,13 @@ stepsResult.pValue
 stepsResult.isSignificant()
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Multiple comparison correction
 
 Testing two metrics (duration and steps) inflates the false-positive rate. <Tooltip tip="Sequentially rejective method that controls the family-wise error rate while being more powerful than Bonferroni">Holm-Bonferroni</Tooltip> correction adjusts p-values to account for this.
 
-[//]: # (<!---FUN abTestingMultipleComparison-->)
+{/*---FUN abTestingMultipleComparison--*/}
 
 ```kotlin
 // Correct for testing two metrics (duration + steps)
@@ -201,13 +201,13 @@ corrected[0] // adjusted p-value for duration
 corrected[1] // adjusted p-value for steps
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Step 5: Correlation Between Metrics
 
 Check whether the two metrics move together within each group.
 
-[//]: # (<!---FUN abTestingCorrelation-->)
+{/*---FUN abTestingCorrelation--*/}
 
 ```kotlin
 // Within the treatment group: do faster sessions correlate with more completed steps?
@@ -217,7 +217,7 @@ correlation.coefficient // negative means shorter sessions correlate with more s
 correlation.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 Spearman correlation is preferred here because one metric (steps) is ordinal.
@@ -227,7 +227,7 @@ Spearman correlation is preferred here because one metric (steps) is ordinal.
 
 When the same users are measured before and after a change, use paired tests.
 
-[//]: # (<!---FUN abTestingPaired-->)
+{/*---FUN abTestingPaired--*/}
 
 ```kotlin
 val beforeMs = doubleArrayOf(
@@ -251,4 +251,4 @@ val dz = differences.mean() / differences.standardDeviation()
 dz // ~6.1 → large effect
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}

--- a/docs/guides/how-to/building-a-pipeline.mdx
+++ b/docs/guides/how-to/building-a-pipeline.mdx
@@ -3,8 +3,8 @@ title: "Building a Statistics Pipeline"
 description: "Organize kstats calls into reusable functions for repeatable analysis workflows."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.PipelineSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.PipelineSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.PipelineSamples--*/}
+{/*---IMPORT org.oremif.kstats.correlation.samples.PipelineSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/building-a-pipeline.ipynb">
   Try this guide as a Kotlin Notebook with Kandy visualizations — run the cells to see charts and explore the data interactively.
@@ -15,7 +15,7 @@ As analysis grows beyond one-off calls, wrapping kstats functions into typed pip
 
 ## Result Types
 
-[//]: # (<!---FUN pipelineResultTypes-->)
+{/*---FUN pipelineResultTypes--*/}
 
 ```kotlin
 data class AssumptionCheck(
@@ -40,11 +40,11 @@ data class AnalysisReport(
 )
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Check Assumptions
 
-[//]: # (<!---FUN pipelineCheckAssumptions-->)
+{/*---FUN pipelineCheckAssumptions--*/}
 
 ```kotlin
 fun checkAssumptions(
@@ -67,13 +67,13 @@ fun checkAssumptions(
 }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Compare Groups
 
 Select the test automatically based on the assumption check.
 
-[//]: # (<!---FUN pipelineCompareGroups-->)
+{/*---FUN pipelineCompareGroups--*/}
 
 ```kotlin
 fun compareGroups(
@@ -97,11 +97,11 @@ fun compareGroups(
 }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Full Report
 
-[//]: # (<!---FUN pipelineFullReport-->)
+{/*---FUN pipelineFullReport--*/}
 
 ```kotlin
 fun analyze(
@@ -121,11 +121,11 @@ fun analyze(
 }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Usage
 
-[//]: # (<!---FUN pipelineUsage-->)
+{/*---FUN pipelineUsage--*/}
 
 ```kotlin
 val pageLoadControl = doubleArrayOf(
@@ -149,13 +149,13 @@ report.comparison.isSignificant
 report.comparison.confidenceInterval
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Extending the Pipeline
 
 Add correlation analysis between metrics:
 
-[//]: # (<!---FUN pipelineExtended-->)
+{/*---FUN pipelineExtended--*/}
 
 ```kotlin
 data class ExtendedReport(
@@ -186,7 +186,7 @@ fun analyzeWithCorrelation(
 }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Module Responsibilities
 

--- a/docs/guides/how-to/choosing-a-distribution.mdx
+++ b/docs/guides/how-to/choosing-a-distribution.mdx
@@ -3,8 +3,8 @@ title: "Choosing a Distribution"
 description: "Match your data to the right probability distribution using domain-driven examples and verification."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.distributions.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.distributions.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/choosing-a-distribution.ipynb">
   Try this guide as a Kotlin Notebook with Kandy visualizations — run the cells to see charts and explore the data interactively.
@@ -33,7 +33,7 @@ Every distribution encodes assumptions about what values are possible and how li
 <Tabs>
 <Tab title="Response times">
 
-[//]: # (<!---FUN choosingResponseTimes-->)
+{/*---FUN choosingResponseTimes--*/}
 
 ```kotlin
 // API response times — often right-skewed with a long tail
@@ -45,12 +45,12 @@ responseTime.quantile(0.99)    // P99 latency
 responseTime.cdf(200.0)        // probability of responding under 200ms
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 <Tab title="Time between events">
 
-[//]: # (<!---FUN choosingTimeBetweenEvents-->)
+{/*---FUN choosingTimeBetweenEvents--*/}
 
 ```kotlin
 // Time between server errors — memoryless waiting process
@@ -61,12 +61,12 @@ timeBetweenErrors.sf(10.0)      // probability of waiting longer than 10 units
 timeBetweenErrors.quantile(0.5) // median waiting time
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 <Tab title="Component lifetime">
 
-[//]: # (<!---FUN choosingComponentLifetime-->)
+{/*---FUN choosingComponentLifetime--*/}
 
 ```kotlin
 // Hardware component lifetime — models wear-out (shape > 1) or burn-in (shape < 1)
@@ -77,7 +77,7 @@ componentLifetime.cdf(3000.0)    // probability of failure before 3000 hours
 componentLifetime.sf(4000.0)     // probability of surviving past 4000 hours
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 </Tabs>
@@ -87,7 +87,7 @@ componentLifetime.sf(4000.0)     // probability of surviving past 4000 hours
 <Tabs>
 <Tab title="Event counts">
 
-[//]: # (<!---FUN choosingEventCounts-->)
+{/*---FUN choosingEventCounts--*/}
 
 ```kotlin
 // Errors per hour on a production server
@@ -98,12 +98,12 @@ errorsPerHour.cdf(5)            // probability of at most 5 errors
 errorsPerHour.quantileInt(0.99) // error count exceeded only 1% of the time
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 <Tab title="Fixed trials">
 
-[//]: # (<!---FUN choosingFixedTrials-->)
+{/*---FUN choosingFixedTrials--*/}
 
 ```kotlin
 // Conversions out of 1000 page views with 3.5% conversion rate
@@ -114,12 +114,12 @@ conversions.pmf(40) // probability of exactly 40 conversions
 conversions.sf(50)  // probability of more than 50 conversions
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 <Tab title="Overdispersed counts">
 
-[//]: # (<!---FUN choosingOverdispersed-->)
+{/*---FUN choosingOverdispersed--*/}
 
 ```kotlin
 // Support tickets until 5th resolution (variance > mean)
@@ -129,14 +129,14 @@ tickets.mean     // expected ticket count
 tickets.variance // larger than mean — overdispersion
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 </Tab>
 </Tabs>
 
 ## Proportions and Rates
 
-[//]: # (<!---FUN choosingProportions-->)
+{/*---FUN choosingProportions--*/}
 
 ```kotlin
 // Click-through rate estimated from 120 clicks in 4000 impressions
@@ -148,11 +148,11 @@ ctr.quantile(0.975) // upper bound
 ctr.cdf(0.035)      // probability that true CTR is below 3.5%
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## General-Purpose Symmetric
 
-[//]: # (<!---FUN choosingSymmetric-->)
+{/*---FUN choosingSymmetric--*/}
 
 ```kotlin
 // User session duration in minutes (roughly symmetric)
@@ -166,13 +166,13 @@ val smallSampleEstimate = StudentTDistribution(degreesOfFreedom = 8.0)
 smallSampleEstimate.quantile(0.975) // critical value for 95% CI
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Verifying the Fit
 
 After choosing a distribution, compare it against observed data using the Kolmogorov-Smirnov test.
 
-[//]: # (<!---FUN choosingVerifyFit-->)
+{/*---FUN choosingVerifyFit--*/}
 
 ```kotlin
 val processingTimesMs = doubleArrayOf(
@@ -191,7 +191,7 @@ ks.statistic // KS statistic — smaller means better fit
 ks.pValue    // high p-value means data does not contradict the distribution
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 A non-significant KS test does not prove the distribution is correct — it means the data does not strongly contradict that choice.

--- a/docs/guides/how-to/exploratory-analysis.mdx
+++ b/docs/guides/how-to/exploratory-analysis.mdx
@@ -3,10 +3,10 @@ title: "Exploratory Data Analysis"
 description: "Walk through a complete EDA workflow on a single dataset using descriptive statistics, distributions, correlations, and comparisons."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.sampling.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.sampling.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.correlation.samples.DocsSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/exploratory-analysis.ipynb">
   Try this guide as a Kotlin Notebook with Kandy visualizations — run the cells to see charts and explore the data interactively.
@@ -17,7 +17,7 @@ This guide analyzes backend service performance metrics collected over 30 days. 
 
 ## Dataset
 
-[//]: # (<!---FUN edaDataset-->)
+{/*---FUN edaDataset--*/}
 
 ```kotlin
 val responseTimeMs = doubleArrayOf(
@@ -45,11 +45,11 @@ val throughputRps = doubleArrayOf(
 )
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Step 1: Summary Statistics
 
-[//]: # (<!---FUN edaSummaryStats-->)
+{/*---FUN edaSummaryStats--*/}
 
 ```kotlin
 val rtSummary = responseTimeMs.describe()
@@ -63,11 +63,11 @@ memSummary.mean; memSummary.standardDeviation; memSummary.min; memSummary.max
 tpSummary.mean; tpSummary.standardDeviation; tpSummary.min; tpSummary.max
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Frequency distribution
 
-[//]: # (<!---FUN edaFrequencyDistribution-->)
+{/*---FUN edaFrequencyDistribution--*/}
 
 ```kotlin
 val rtBins = responseTimeMs.frequencyTable(binCount = 5)
@@ -81,11 +81,11 @@ errBins.forEach { bin ->
 }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Step 2: Distribution Shape
 
-[//]: # (<!---FUN edaDistributionShape-->)
+{/*---FUN edaDistributionShape--*/}
 
 ```kotlin
 responseTimeMs.skewness() // positive = right-skewed
@@ -98,11 +98,11 @@ memoryUsageMb.skewness()
 throughputRps.skewness()
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Normality tests
 
-[//]: # (<!---FUN edaNormalityTests-->)
+{/*---FUN edaNormalityTests--*/}
 
 ```kotlin
 shapiroWilkTest(responseTimeMs).pValue
@@ -111,11 +111,11 @@ shapiroWilkTest(memoryUsageMb).pValue
 shapiroWilkTest(throughputRps).pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Fit a candidate distribution
 
-[//]: # (<!---FUN edaFitDistribution-->)
+{/*---FUN edaFitDistribution--*/}
 
 ```kotlin
 val rtFit = NormalDistribution(
@@ -131,11 +131,11 @@ val memFit = NormalDistribution(
 kolmogorovSmirnovTest(memoryUsageMb, memFit).pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Step 3: Correlations
 
-[//]: # (<!---FUN edaCorrelations-->)
+{/*---FUN edaCorrelations--*/}
 
 ```kotlin
 // Correlation matrix across all four metrics
@@ -152,11 +152,11 @@ rtVsThroughput.coefficient // negative = latency rises when throughput drops
 rtVsThroughput.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Regression
 
-[//]: # (<!---FUN edaRegression-->)
+{/*---FUN edaRegression--*/}
 
 ```kotlin
 // Model: how does error count relate to response time?
@@ -169,13 +169,13 @@ regression.rSquared  // proportion of variance explained
 regression.predict(4.0) // expected latency at 4 errors/hour
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Step 4: Compare Periods
 
 Split the data into two halves and check whether performance changed.
 
-[//]: # (<!---FUN edaComparePeriods-->)
+{/*---FUN edaComparePeriods--*/}
 
 ```kotlin
 val firstHalfRt = responseTimeMs.sliceArray(0 until 15)
@@ -190,11 +190,11 @@ val periodRank = mannWhitneyUTest(firstHalfRt, secondHalfRt)
 periodRank.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Compare throughput between periods:
 
-[//]: # (<!---FUN edaCompareThroughput-->)
+{/*---FUN edaCompareThroughput--*/}
 
 ```kotlin
 val firstHalfTp = throughputRps.sliceArray(0 until 15)
@@ -204,13 +204,13 @@ val tpComparison = tTest(firstHalfTp, secondHalfTp)
 tpComparison.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Step 5: Normalize and Rank
 
 Compare metrics on a common scale.
 
-[//]: # (<!---FUN edaNormalizeRank-->)
+{/*---FUN edaNormalizeRank--*/}
 
 ```kotlin
 // Z-score: values become standard deviations from mean
@@ -226,7 +226,7 @@ val tpScaled = throughputRps.minMaxNormalize()
 val rtRanked = responseTimeMs.rank()
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Z-score normalization is useful for combining metrics into a composite score:

--- a/docs/guides/how-to/quality-control.mdx
+++ b/docs/guides/how-to/quality-control.mdx
@@ -3,10 +3,10 @@ title: "Quality Control"
 description: "Detect anomalies, set control limits, and monitor process stability using statistical methods."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.sampling.samples.DocsSamples-->)
-[//]: # (<!---IMPORT org.oremif.kstats.correlation.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.sampling.samples.DocsSamples--*/}
+{/*---IMPORT org.oremif.kstats.correlation.samples.DocsSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/quality-control.ipynb">
   Try this guide as a Kotlin Notebook with Kandy visualizations — run the cells to see charts and explore the data interactively.
@@ -17,7 +17,7 @@ This guide uses temperature sensor readings from a manufacturing line to demonst
 
 ## Process Data
 
-[//]: # (<!---FUN qcProcessData-->)
+{/*---FUN qcProcessData--*/}
 
 ```kotlin
 // Temperature readings (°C) from sensor on production line
@@ -29,13 +29,13 @@ val sensorReadings = doubleArrayOf(
 // Two potential outliers: 162.5 and 141.3
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Anomaly Detection
 
 ### Baseline statistics
 
-[//]: # (<!---FUN qcBaselineStats-->)
+{/*---FUN qcBaselineStats--*/}
 
 ```kotlin
 val summary = sensorReadings.describe()
@@ -47,13 +47,13 @@ summary.max // check for unusually high values
 summary.interquartileRange
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Z-score method
 
 Flag readings more than 3 standard deviations from the mean.
 
-[//]: # (<!---FUN qcZScore-->)
+{/*---FUN qcZScore--*/}
 
 ```kotlin
 val zScores = sensorReadings.zScore()
@@ -62,13 +62,13 @@ val anomalyIndices = zScores.indices.filter { kotlin.math.abs(zScores[it]) > 3.0
 val anomalies = anomalyIndices.map { sensorReadings[it] }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Percentile-based detection
 
 Flag readings outside the 1st and 99th percentiles.
 
-[//]: # (<!---FUN qcPercentileDetection-->)
+{/*---FUN qcPercentileDetection--*/}
 
 ```kotlin
 val lowerBound = sensorReadings.quantile(0.01)
@@ -77,13 +77,13 @@ val upperBound = sensorReadings.quantile(0.99)
 val outliers = sensorReadings.filter { it < lowerBound || it > upperBound }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Control Limits
 
 Compute mean ± 3σ boundaries.
 
-[//]: # (<!---FUN qcControlLimits-->)
+{/*---FUN qcControlLimits--*/}
 
 ```kotlin
 val centerLine = sensorReadings.mean()
@@ -95,13 +95,13 @@ val lowerControlLimit = centerLine - 3 * sigma
 val outOfControl = sensorReadings.filter { it > upperControlLimit || it < lowerControlLimit }
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Batch Stability
 
 Compare readings from two production batches to verify the process has not shifted.
 
-[//]: # (<!---FUN qcBatchStability-->)
+{/*---FUN qcBatchStability--*/}
 
 ```kotlin
 val morningBatch = doubleArrayOf(
@@ -124,11 +124,11 @@ batchComparison.pValue
 batchComparison.isSignificant() // false means no significant shift
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Multiple batches
 
-[//]: # (<!---FUN qcMultipleBatches-->)
+{/*---FUN qcMultipleBatches--*/}
 
 ```kotlin
 val batch1 = doubleArrayOf(155.2, 154.8, 156.1, 155.5, 154.3)
@@ -140,13 +140,13 @@ anova.fStatistic
 anova.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Distribution Fit
 
 Verify that readings follow the expected distribution.
 
-[//]: # (<!---FUN qcDistributionFit-->)
+{/*---FUN qcDistributionFit--*/}
 
 ```kotlin
 // Exclude known outliers for fitting
@@ -161,7 +161,7 @@ val ks = kolmogorovSmirnovTest(cleanReadings, fitted)
 ks.pValue // high p-value supports the normal process model
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 After fitting a process distribution, use `quantile()` to set thresholds:
@@ -172,7 +172,7 @@ After fitting a process distribution, use `quantile()` to set thresholds:
 
 When monitoring several sensors, check correlations between them.
 
-[//]: # (<!---FUN qcMultiParameter-->)
+{/*---FUN qcMultiParameter--*/}
 
 ```kotlin
 val temperatureSensor = doubleArrayOf(
@@ -196,7 +196,7 @@ val matrix = correlationMatrix(temperatureSensor, pressureSensor, flowRateSensor
 // matrix[1][2] = pressure-flow correlation
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 Strong correlations between sensor readings can indicate shared root causes when one parameter drifts out of control.

--- a/docs/guides/how-to/testing-assumptions.mdx
+++ b/docs/guides/how-to/testing-assumptions.mdx
@@ -3,7 +3,7 @@ title: "Testing Assumptions"
 description: "Verify normality, variance homogeneity, and distributional fit before applying parametric methods."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
 
 <Card title="Kotlin Notebook" icon="notebook" href="https://github.com/Oremif/kstats/blob/master/samples/testing-assumptions.ipynb">
   Try this guide as a Kotlin Notebook with Kandy visualizations — run the cells to see charts and explore the data interactively.
@@ -25,7 +25,7 @@ Parametric methods (t-tests, ANOVA, Pearson correlation) assume specific propert
 
 ### Run all four on the same dataset
 
-[//]: # (<!---FUN testingNormality-->)
+{/*---FUN testingNormality--*/}
 
 ```kotlin
 val sensorReadings = doubleArrayOf(
@@ -45,7 +45,7 @@ dagostino.pValue  // D'Agostino-Pearson
 jarqueBera.pValue // Jarque-Bera
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 When tests disagree, prefer Shapiro-Wilk for small to medium samples and Anderson-Darling when tail behavior matters.
@@ -53,7 +53,7 @@ When tests disagree, prefer Shapiro-Wilk for small to medium samples and Anderso
 
 ### Combine with descriptive statistics
 
-[//]: # (<!---FUN testingNormalityDescriptive-->)
+{/*---FUN testingNormalityDescriptive--*/}
 
 ```kotlin
 val summary = sensorReadings.describe()
@@ -61,7 +61,7 @@ summary.skewness // close to 0 for symmetric data
 summary.kurtosis // close to 0 (excess) for Normal-like tails
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Variance Homogeneity
 
@@ -75,7 +75,7 @@ When comparing groups (t-test, ANOVA), equal variances are often assumed.
 
 ### Check variances before ANOVA
 
-[//]: # (<!---FUN testingVarianceHomogeneity-->)
+{/*---FUN testingVarianceHomogeneity--*/}
 
 ```kotlin
 val batchA = doubleArrayOf(48.2, 47.8, 49.1, 48.5, 47.9, 48.7, 48.3, 49.0, 48.1, 48.6)
@@ -91,13 +91,13 @@ bartlett.pValue // Bartlett
 fligner.pValue  // Fligner-Killeen
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 A high p-value from all three tests supports proceeding with ANOVA or equal-variance t-test.
 
 ### Then run ANOVA
 
-[//]: # (<!---FUN testingVarianceThenAnova-->)
+{/*---FUN testingVarianceThenAnova--*/}
 
 ```kotlin
 val anova = oneWayAnova(batchA, batchB, batchC)
@@ -105,7 +105,7 @@ anova.fStatistic
 anova.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Goodness-of-Fit
 
@@ -113,7 +113,7 @@ anova.pValue
 
 Compare observed data against a theoretical distribution.
 
-[//]: # (<!---FUN testingKsOneSample-->)
+{/*---FUN testingKsOneSample--*/}
 
 ```kotlin
 val temperatureReadings = doubleArrayOf(
@@ -132,13 +132,13 @@ ks.statistic // smaller means better fit
 ks.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Chi-squared goodness-of-fit
 
 Test whether observed category counts match expected proportions.
 
-[//]: # (<!---FUN testingChiSquared-->)
+{/*---FUN testingChiSquared--*/}
 
 ```kotlin
 // Defect counts across 5 product categories
@@ -154,13 +154,13 @@ val specific = chiSquaredTest(observedDefects, expectedCounts)
 specific.pValue
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Two-sample KS test
 
 Compare two samples without assuming a specific distribution.
 
-[//]: # (<!---FUN testingKsTwoSample-->)
+{/*---FUN testingKsTwoSample--*/}
 
 ```kotlin
 val morningReadings = doubleArrayOf(
@@ -174,4 +174,4 @@ val twoSampleKs = kolmogorovSmirnovTest(morningReadings, nightReadings)
 twoSampleKs.pValue // low p-value suggests different underlying distributions
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}

--- a/docs/hypothesis/overview.mdx
+++ b/docs/hypothesis/overview.mdx
@@ -3,7 +3,7 @@ title: "Hypothesis Tests"
 description: "t-tests, ANOVA, chi-squared, Fisher exact, Mann-Whitney, Wilcoxon, normality tests, and variance homogeneity tests in kstats-hypothesis."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.hypothesis.samples.DocsSamples--*/}
 
 `kstats-hypothesis` provides statistical tests organized by the question they answer. Most functions return a `TestResult`; `oneWayAnova()` returns an `AnovaResult` with the full ANOVA table.
 
@@ -11,7 +11,7 @@ description: "t-tests, ANOVA, chi-squared, Fisher exact, Mann-Whitney, Wilcoxon,
 
 Every test produces a result with a consistent shape. The `statistic` is the computed test value, `pValue` is the probability of observing a result at least as extreme under the null hypothesis, and `isSignificant()` compares the p-value to a threshold.
 
-[//]: # (<!---FUN hypTestResult-->)
+{/*---FUN hypTestResult--*/}
 
 ```kotlin
 val sample = doubleArrayOf(5.0, 6.0, 7.0, 5.5, 6.5)
@@ -25,7 +25,7 @@ result.isSignificant()   // true (p < 0.05)
 result.confidenceInterval // (5.02, 6.98)
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 `isSignificant()` defaults to $\alpha = 0.05$. Pass a different threshold explicitly: `result.isSignificant(alpha = 0.01)`.
@@ -39,7 +39,7 @@ Set `alternative` explicitly for one-sided tests. The default is `Alternative.TW
 
 The one-sample t-test compares the mean of a single sample against a known or hypothesized value.
 
-[//]: # (<!---FUN hypOneSample-->)
+{/*---FUN hypOneSample--*/}
 
 ```kotlin
 val sample = doubleArrayOf(5.1, 4.9, 5.3, 5.0, 4.8)
@@ -54,7 +54,7 @@ val one = tTest(sample, mu = 5.0, alternative = Alternative.GREATER)
 one.pValue               // one-sided p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Use `Alternative.GREATER` or `Alternative.LESS` for directional hypotheses instead of halving a two-sided p-value. The confidence interval adjusts accordingly.
@@ -66,7 +66,7 @@ Use `Alternative.GREATER` or `Alternative.LESS` for directional hypotheses inste
 
 Compares the means of two independent samples. Welch's t-test (unequal variances) is the default.
 
-[//]: # (<!---FUN hypTwoSample-->)
+{/*---FUN hypTwoSample--*/}
 
 ```kotlin
 val group1 = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -78,7 +78,7 @@ result.pValue            // 0.0011
 result.isSignificant()   // true
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Warning>
 `equalVariances` is `false` by default, meaning Welch's t-test is used. Set `equalVariances = true` only after confirming equal variances with `leveneTest()` or `bartlettTest()`.
@@ -88,11 +88,11 @@ result.isSignificant()   // true
 
 Compares two related measurements (before/after, left/right) on the same subjects.
 
-[//]: # (<!---FUN hypPaired-->)
+{/*---FUN hypPaired--*/}
 
 ```kotlin
 val before = doubleArrayOf(200.0, 190.0, 210.0, 180.0, 195.0)
-val after  = doubleArrayOf(190.0, 180.0, 195.0, 170.0, 185.0)
+val after = doubleArrayOf(190.0, 180.0, 195.0, 170.0, 185.0)
 
 val result = pairedTTest(before, after)
 result.statistic         // positive t (before > after)
@@ -100,13 +100,13 @@ result.pValue            // p-value for the difference
 result.isSignificant()   // true if the change is significant
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Mann-Whitney U test
 
 Non-parametric alternative to the two-sample t-test. Compares ranks instead of means.
 
-[//]: # (<!---FUN hypMannWhitney-->)
+{/*---FUN hypMannWhitney--*/}
 
 ```kotlin
 val group1 = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -118,24 +118,24 @@ result.pValue            // < 0.02
 result.isSignificant()   // true
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Wilcoxon signed-rank test
 
 Non-parametric alternative to the paired t-test. Tests whether paired differences are symmetrically distributed around zero.
 
-[//]: # (<!---FUN hypWilcoxon-->)
+{/*---FUN hypWilcoxon--*/}
 
 ```kotlin
 val before = doubleArrayOf(10.0, 12.0, 14.0, 16.0, 18.0)
-val after  = doubleArrayOf(8.0, 9.0, 11.0, 12.0, 13.0)
+val after = doubleArrayOf(8.0, 9.0, 11.0, 12.0, 13.0)
 
 val result = wilcoxonSignedRankTest(before, after)
 result.statistic         // W+ = 15.0
 result.pValue            // p-value with continuity correction
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Are three or more groups different?
 
@@ -143,7 +143,7 @@ result.pValue            // p-value with continuity correction
 
 Tests whether the means of three or more groups differ. Returns `AnovaResult` with the full ANOVA table.
 
-[//]: # (<!---FUN hypAnova-->)
+{/*---FUN hypAnova--*/}
 
 ```kotlin
 val g1 = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -161,7 +161,7 @@ anova.msBetween          // 125.0
 anova.msWithin           // 2.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 ANOVA assumes normality within each group and equal variances across groups. Check normality with `shapiroWilkTest()` and equal variances with `leveneTest()` or `bartlettTest()` before running ANOVA.
@@ -171,7 +171,7 @@ ANOVA assumes normality within each group and equal variances across groups. Che
 
 Non-parametric alternative to repeated-measures ANOVA. Compares ranks across matched groups.
 
-[//]: # (<!---FUN hypFriedman-->)
+{/*---FUN hypFriedman--*/}
 
 ```kotlin
 val treatment1 = doubleArrayOf(5.0, 6.0, 7.0, 5.5, 6.5)
@@ -183,13 +183,13 @@ result.statistic         // Friedman chi-squared
 result.pValue            // p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## Is my data normally distributed?
 
 Four normality tests are available. Each returns a `TestResult` — a significant result (low p-value) indicates evidence against normality.
 
-[//]: # (<!---FUN hypNormality-->)
+{/*---FUN hypNormality--*/}
 
 ```kotlin
 val sample = doubleArrayOf(
@@ -203,7 +203,7 @@ dagostinoPearsonTest(sample).pValue  // combines skewness and kurtosis tests
 jarqueBeraTest(sample).pValue        // asymptotic test based on skewness and kurtosis
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Shapiro-Wilk is the most common choice and generally the most powerful for small-to-moderate samples (n &lt; 5000). Anderson-Darling is more sensitive to deviations in the tails. D'Agostino-Pearson and Jarque-Bera are faster for large samples.
@@ -215,7 +215,7 @@ Shapiro-Wilk is the most common choice and generally the most powerful for small
 
 Tests whether observed counts match expected frequencies.
 
-[//]: # (<!---FUN hypChiSquared-->)
+{/*---FUN hypChiSquared--*/}
 
 ```kotlin
 val observed = intArrayOf(50, 30, 20)
@@ -227,13 +227,13 @@ result.pValue            // 0.0821
 result.isSignificant()   // false at α = 0.05
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### G-test
 
 Likelihood-ratio alternative to the chi-squared test. Often preferred for small expected counts.
 
-[//]: # (<!---FUN hypGTest-->)
+{/*---FUN hypGTest--*/}
 
 ```kotlin
 val observed = intArrayOf(50, 30, 20)
@@ -244,13 +244,13 @@ result.statistic         // G statistic
 result.pValue            // p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Binomial test
 
 Tests whether the observed proportion of successes matches a hypothesized probability.
 
-[//]: # (<!---FUN hypBinomial-->)
+{/*---FUN hypBinomial--*/}
 
 ```kotlin
 val result = binomialTest(successes = 60, trials = 100, probability = 0.5)
@@ -258,13 +258,13 @@ result.pValue            // p-value for H₀: p = 0.5
 result.isSignificant()   // true if 60/100 is significantly different from 0.5
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ### Fisher exact test
 
 Exact test for 2×2 contingency tables. Preferred over chi-squared for small samples.
 
-[//]: # (<!---FUN hypFisher-->)
+{/*---FUN hypFisher--*/}
 
 ```kotlin
 // 2×2 table: [[10, 30], [20, 40]]
@@ -273,7 +273,7 @@ result.pValue            // exact p-value
 result.isSignificant()   // true or false
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Warning>
 Fisher exact test is designed for small contingency tables. For larger tables, use `chiSquaredTest()` with a chi-squared test of independence.
@@ -283,7 +283,7 @@ Fisher exact test is designed for small contingency tables. For larger tables, u
 
 Variance homogeneity is an assumption of ANOVA and some t-test variants. Three tests are available:
 
-[//]: # (<!---FUN hypVarianceHomogeneity-->)
+{/*---FUN hypVarianceHomogeneity--*/}
 
 ```kotlin
 val g1 = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -295,7 +295,7 @@ bartlettTest(g1, g2, g3).pValue       // most powerful when normality holds
 flignerKilleenTest(g1, g2, g3).pValue // rank-based, robust to outliers
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 Levene's test is the safest default — it is robust to non-normality. Use Bartlett's test only when the data within each group is approximately normal (Bartlett is more powerful in that case). Fligner-Killeen is the most robust to outliers.
@@ -307,7 +307,7 @@ Levene's test is the safest default — it is robust to non-normality. Use Bartl
 
 The two-sample KS test compares whether two samples come from the same continuous distribution.
 
-[//]: # (<!---FUN hypKolmogorovSmirnov-->)
+{/*---FUN hypKolmogorovSmirnov--*/}
 
 ```kotlin
 val sample1 = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -318,7 +318,7 @@ result.statistic         // D = max difference between ECDFs
 result.pValue            // p-value
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 ## The Alternative Enum
 

--- a/docs/sampling/overview.mdx
+++ b/docs/sampling/overview.mdx
@@ -3,7 +3,7 @@ title: "Sampling & Transformation"
 description: "Ranking, z-score normalization, min-max scaling, binning, frequency tables, bootstrap, random sampling, and weighted dice in kstats-sampling."
 ---
 
-[//]: # (<!---IMPORT org.oremif.kstats.sampling.samples.DocsSamples-->)
+{/*---IMPORT org.oremif.kstats.sampling.samples.DocsSamples--*/}
 
 `kstats-sampling` provides preprocessing and resampling utilities that sit at the edges of an analysis workflow. The module covers two distinct areas: transforming numeric data and drawing random samples.
 
@@ -13,7 +13,7 @@ description: "Ranking, z-score normalization, min-max scaling, binning, frequenc
 
 `rank()` replaces numeric values with their ordered positions. Tie handling is controlled by the `TieMethod` parameter.
 
-[//]: # (<!---FUN sampRanking-->)
+{/*---FUN sampRanking--*/}
 
 ```kotlin
 val data = doubleArrayOf(3.0, 1.0, 4.0, 1.0, 5.0)
@@ -27,7 +27,7 @@ data.rank(TieMethod.ORDINAL)       // [3.0, 1.0, 4.0, 2.0, 5.0]
 data.percentileRank()              // ranks scaled to 0-100
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Tip>
 `TieMethod` options:
@@ -42,7 +42,7 @@ data.percentileRank()              // ranks scaled to 0-100
 
 Two standard scaling methods: z-score standardization (mean 0, standard deviation 1) and min-max scaling.
 
-[//]: # (<!---FUN sampNormalization-->)
+{/*---FUN sampNormalization--*/}
 
 ```kotlin
 val data = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
@@ -53,7 +53,7 @@ data.minMaxNormalize()             // [0.0, 0.25, 0.5, 0.75, 1.0]
 data.minMaxNormalize(0.0, 100.0)   // [0.0, 25.0, 50.0, 75.0, 100.0]
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 `zScore()` is appropriate when the downstream method assumes standardized input. `minMaxNormalize()` scales to [0, 1] by default, or to a custom range.
 
@@ -71,7 +71,7 @@ $$
 
 `bin()` groups values into equal-width intervals and returns the items in each bin. `frequencyTable()` returns interval boundaries, counts, relative frequencies, and cumulative frequencies.
 
-[//]: # (<!---FUN sampBinning-->)
+{/*---FUN sampBinning--*/}
 
 ```kotlin
 val data = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
@@ -93,7 +93,7 @@ freq[0].relativeFrequency          // proportion of total
 freq[0].cumulativeFrequency        // running total of relative frequencies
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 `bin()` returns the actual items that fall into each interval — useful for further processing. `frequencyTable()` returns summary statistics per bin — useful for histogram-like reports.
 
@@ -107,7 +107,7 @@ Both `bin()` and `frequencyTable()` accept either a **bin count** (number of bin
 
 `randomSample()` draws without replacement. `bootstrapSample()` draws with replacement — the same element can appear multiple times.
 
-[//]: # (<!---FUN sampRandomBootstrap-->)
+{/*---FUN sampRandomBootstrap--*/}
 
 ```kotlin
 val items = listOf("A", "B", "C", "D", "E")
@@ -116,7 +116,7 @@ items.randomSample(3, Random(42))     // 3 distinct items
 items.bootstrapSample(6, Random(42))  // 6 items, may have repeats
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 <Note>
 `randomSample()` draws **without replacement** — each element appears at most once. The sample size must not exceed the collection size.
@@ -128,7 +128,7 @@ items.bootstrapSample(6, Random(42))  // 6 items, may have repeats
 
 `WeightedCoin` simulates a biased coin flip. `WeightedDice` simulates a weighted random selection from a set of outcomes.
 
-[//]: # (<!---FUN sampWeightedRandom-->)
+{/*---FUN sampWeightedRandom--*/}
 
 ```kotlin
 val coin = WeightedCoin(probability = 0.7)
@@ -138,7 +138,7 @@ val dice = WeightedDice(mapOf("A" to 3.0, "B" to 1.0))
 dice.roll()                        // "A" with 75% probability, "B" with 25%
 ```
 
-[//]: # (<!---END-->)
+{/*---END--*/}
 
 Weights do not need to sum to 1 — they are normalized internally. `WeightedDice` works with any type as the outcome.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ vanniktechMavenPublish = "0.36.0"
 dokka = "2.2.0"
 bcv = "0.18.1"
 
-korro = "0.1.6"
+korro = "0.2.0"
 kotlinxBenchmark = "0.4.16"
 
 commonsMath3 = "3.6.1"


### PR DESCRIPTION
## Description

Upgrade the korro Gradle plugin from 0.1.6 to 0.2.0. The plugin id and markdown directive grammar are unchanged, but the DSL is now nested and `Property`-based, and `.mdx` files gain a native JSX-expression directive form that replaces the `[//]: # (<!---...-->)` workaround previously needed for MDX v2 tooling.

- bump `korro` in the version catalog to 0.2.0
- migrate the `korro { }` block in `build.gradle.kts` to the new nested API (`docs { from(...); baseDir.set(...) }`, `samples { from(...) }`); `baseDir` is now mandatory
- rewrite 578 directive occurrences across 26 `.mdx` files from `[//]: # (<!---...-->)` to `{/*---...--*/}` (IMPORT/FUN/END)

`.md` files (README, Module.md, dokka/modules.md) are unchanged — the HTML-comment directive form still works there.

## Testing

`./gradlew korroGenerate` and `./gradlew korroCheck` both pass locally against the migrated config.

## Checklist

- [x] Existing tests pass
- [ ] New/updated tests for changed behavior
- [x] New/updated documentation if necessary