### PR TITLE
feat: add CUSUM (Cumulative Sum) control chart (#36)

### DIFF
--- a/kstats-core/api/jvm/kstats-core.api
+++ b/kstats-core/api/jvm/kstats-core.api
@@ -88,6 +88,9 @@ public final class org/oremif/kstats/descriptive/CentralTendencyKt {
 }
 
 public final class org/oremif/kstats/descriptive/ControlChartKt {
+	public static final fun cusum (Ljava/lang/Iterable;DDD)Lorg/oremif/kstats/descriptive/CusumResult;
+	public static final fun cusum (Lkotlin/sequences/Sequence;DDD)Lorg/oremif/kstats/descriptive/CusumResult;
+	public static final fun cusum ([DDDD)Lorg/oremif/kstats/descriptive/CusumResult;
 	public static final fun spcConstants (I)Lorg/oremif/kstats/descriptive/SpcConstants;
 	public static final fun xBarRChart (Ljava/util/List;)Lorg/oremif/kstats/descriptive/XBarRChartResult;
 	public static final fun xBarSChart (Ljava/util/List;)Lorg/oremif/kstats/descriptive/XBarSChartResult;
@@ -104,6 +107,21 @@ public final class org/oremif/kstats/descriptive/ControlChartLimits {
 	public final fun getCenterLine ()D
 	public final fun getLcl ()D
 	public final fun getUcl ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/oremif/kstats/descriptive/CusumResult {
+	public fun <init> ([D[DI)V
+	public final fun component1 ()[D
+	public final fun component2 ()[D
+	public final fun component3 ()I
+	public final fun copy ([D[DI)Lorg/oremif/kstats/descriptive/CusumResult;
+	public static synthetic fun copy$default (Lorg/oremif/kstats/descriptive/CusumResult;[D[DIILjava/lang/Object;)Lorg/oremif/kstats/descriptive/CusumResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlarmIndex ()I
+	public final fun getSMinus ()[D
+	public final fun getSPlus ()[D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/kstats-core/api/kstats-core.klib.api
+++ b/kstats-core/api/kstats-core.klib.api
@@ -161,6 +161,25 @@ final class org.oremif.kstats.descriptive/ControlChartLimits { // org.oremif.kst
     final fun toString(): kotlin/String // org.oremif.kstats.descriptive/ControlChartLimits.toString|toString(){}[0]
 }
 
+final class org.oremif.kstats.descriptive/CusumResult { // org.oremif.kstats.descriptive/CusumResult|null[0]
+    constructor <init>(kotlin/DoubleArray, kotlin/DoubleArray, kotlin/Int) // org.oremif.kstats.descriptive/CusumResult.<init>|<init>(kotlin.DoubleArray;kotlin.DoubleArray;kotlin.Int){}[0]
+
+    final val alarmIndex // org.oremif.kstats.descriptive/CusumResult.alarmIndex|{}alarmIndex[0]
+        final fun <get-alarmIndex>(): kotlin/Int // org.oremif.kstats.descriptive/CusumResult.alarmIndex.<get-alarmIndex>|<get-alarmIndex>(){}[0]
+    final val sMinus // org.oremif.kstats.descriptive/CusumResult.sMinus|{}sMinus[0]
+        final fun <get-sMinus>(): kotlin/DoubleArray // org.oremif.kstats.descriptive/CusumResult.sMinus.<get-sMinus>|<get-sMinus>(){}[0]
+    final val sPlus // org.oremif.kstats.descriptive/CusumResult.sPlus|{}sPlus[0]
+        final fun <get-sPlus>(): kotlin/DoubleArray // org.oremif.kstats.descriptive/CusumResult.sPlus.<get-sPlus>|<get-sPlus>(){}[0]
+
+    final fun component1(): kotlin/DoubleArray // org.oremif.kstats.descriptive/CusumResult.component1|component1(){}[0]
+    final fun component2(): kotlin/DoubleArray // org.oremif.kstats.descriptive/CusumResult.component2|component2(){}[0]
+    final fun component3(): kotlin/Int // org.oremif.kstats.descriptive/CusumResult.component3|component3(){}[0]
+    final fun copy(kotlin/DoubleArray = ..., kotlin/DoubleArray = ..., kotlin/Int = ...): org.oremif.kstats.descriptive/CusumResult // org.oremif.kstats.descriptive/CusumResult.copy|copy(kotlin.DoubleArray;kotlin.DoubleArray;kotlin.Int){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // org.oremif.kstats.descriptive/CusumResult.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // org.oremif.kstats.descriptive/CusumResult.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // org.oremif.kstats.descriptive/CusumResult.toString|toString(){}[0]
+}
+
 final class org.oremif.kstats.descriptive/DescriptiveStatistics { // org.oremif.kstats.descriptive/DescriptiveStatistics|null[0]
     constructor <init>(kotlin/Long, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double, kotlin/Double) // org.oremif.kstats.descriptive/DescriptiveStatistics.<init>|<init>(kotlin.Long;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double;kotlin.Double){}[0]
 
@@ -473,6 +492,9 @@ final fun org.oremif.kstats.core/regularizedGammaP(kotlin/Double, kotlin/Double)
 final fun org.oremif.kstats.core/regularizedGammaQ(kotlin/Double, kotlin/Double): kotlin/Double // org.oremif.kstats.core/regularizedGammaQ|regularizedGammaQ(kotlin.Double;kotlin.Double){}[0]
 final fun org.oremif.kstats.core/secureRandom(): kotlin.random/Random // org.oremif.kstats.core/secureRandom|secureRandom(){}[0]
 final fun org.oremif.kstats.core/trigamma(kotlin/Double): kotlin/Double // org.oremif.kstats.core/trigamma|trigamma(kotlin.Double){}[0]
+final fun org.oremif.kstats.descriptive/cusum(kotlin.collections/Iterable<kotlin/Double>, kotlin/Double, kotlin/Double, kotlin/Double): org.oremif.kstats.descriptive/CusumResult // org.oremif.kstats.descriptive/cusum|cusum(kotlin.collections.Iterable<kotlin.Double>;kotlin.Double;kotlin.Double;kotlin.Double){}[0]
+final fun org.oremif.kstats.descriptive/cusum(kotlin.sequences/Sequence<kotlin/Double>, kotlin/Double, kotlin/Double, kotlin/Double): org.oremif.kstats.descriptive/CusumResult // org.oremif.kstats.descriptive/cusum|cusum(kotlin.sequences.Sequence<kotlin.Double>;kotlin.Double;kotlin.Double;kotlin.Double){}[0]
+final fun org.oremif.kstats.descriptive/cusum(kotlin/DoubleArray, kotlin/Double, kotlin/Double, kotlin/Double): org.oremif.kstats.descriptive/CusumResult // org.oremif.kstats.descriptive/cusum|cusum(kotlin.DoubleArray;kotlin.Double;kotlin.Double;kotlin.Double){}[0]
 final fun org.oremif.kstats.descriptive/spcConstants(kotlin/Int): org.oremif.kstats.descriptive/SpcConstants // org.oremif.kstats.descriptive/spcConstants|spcConstants(kotlin.Int){}[0]
 final fun org.oremif.kstats.descriptive/xBarRChart(kotlin.collections/List<kotlin/DoubleArray>): org.oremif.kstats.descriptive/XBarRChartResult // org.oremif.kstats.descriptive/xBarRChart|xBarRChart(kotlin.collections.List<kotlin.DoubleArray>){}[0]
 final fun org.oremif.kstats.descriptive/xBarSChart(kotlin.collections/List<kotlin/DoubleArray>): org.oremif.kstats.descriptive/XBarSChartResult // org.oremif.kstats.descriptive/xBarSChart|xBarSChart(kotlin.collections.List<kotlin.DoubleArray>){}[0]

--- a/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/ControlChart.kt
+++ b/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/ControlChart.kt
@@ -287,6 +287,204 @@ public fun xBarSChart(subgroups: List<DoubleArray>): XBarSChartResult {
     )
 }
 
+// ── CUSUM chart ────────────────────────────────────────────────────────────────
+
+/**
+ * Results of a two-sided tabular CUSUM control chart analysis.
+ *
+ * Holds the per-observation upper (C⁺) and lower (C⁻) cumulative sums produced by the
+ * tabular CUSUM algorithm, together with the index of the first observation at which an
+ * out-of-control signal fired. The upper sum C⁺ accumulates positive deviations above
+ * the target; the lower sum C⁻ accumulates negative deviations below the target. An
+ * alarm is signaled as soon as either sum exceeds the decision interval H.
+ *
+ * @property sPlus the sequence of upper cumulative sums C⁺ᵢ, one entry per observation.
+ * Each value is non-negative; a rising C⁺ indicates a sustained positive shift from target.
+ * @property sMinus the sequence of lower cumulative sums C⁻ᵢ, one entry per observation.
+ * Each value is non-negative; a rising C⁻ indicates a sustained negative shift from target.
+ * @property alarmIndex the zero-based index of the first observation at which C⁺ > H or
+ * C⁻ > H, or `-1` if no alarm was triggered anywhere in the series.
+ * @see cusum
+ */
+public data class CusumResult(
+    val sPlus: DoubleArray,
+    val sMinus: DoubleArray,
+    val alarmIndex: Int,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CusumResult) return false
+        return alarmIndex == other.alarmIndex &&
+            sPlus.contentEquals(other.sPlus) &&
+            sMinus.contentEquals(other.sMinus)
+    }
+
+    override fun hashCode(): Int {
+        var result = sPlus.contentHashCode()
+        result = 31 * result + sMinus.contentHashCode()
+        result = 31 * result + alarmIndex
+        return result
+    }
+}
+
+/**
+ * Computes a two-sided tabular CUSUM control chart for the given [observations].
+ *
+ * The cumulative sum (CUSUM) chart is designed to detect small, sustained shifts in the
+ * process mean more quickly than a Shewhart chart such as [xBarRChart] or [xBarSChart].
+ * Where a Shewhart chart reacts only to each single observation, CUSUM accumulates
+ * deviations from the reference mean over time, so even a drift of roughly 0.5σ–1σ is
+ * detected within a few observations.
+ *
+ * This implementation uses the standard tabular two-sided formulation:
+ *
+ * ```
+ *   C⁺ᵢ = max(0, C⁺ᵢ₋₁ + (xᵢ − μ₀ − K))
+ *   C⁻ᵢ = max(0, C⁻ᵢ₋₁ + (μ₀ − K − xᵢ))
+ * ```
+ *
+ * with C⁺₀ = C⁻₀ = 0. An out-of-control signal is raised at the first index where
+ * C⁺ᵢ > H or C⁻ᵢ > H.
+ *
+ * The allowance [k] (often denoted K) is typically chosen as half the magnitude of the
+ * shift (in σ units) that one wants to detect — a common default is K ≈ 0.5σ, which
+ * targets a 1σ shift. The decision interval [h] (often denoted H) is typically set to
+ * 4σ or 5σ, giving an in-control average run length comparable to a 3σ Shewhart chart
+ * while reacting much faster to small shifts.
+ *
+ * NaN values in the data propagate through the computation (IEEE 754 semantics).
+ *
+ * ### Example:
+ * ```kotlin
+ * // Process with target 10.0, drifting upward after observation 4.
+ * val observations = doubleArrayOf(10.0, 10.1, 9.9, 10.0, 10.2, 10.5, 10.7, 10.9, 11.1)
+ * val result = cusum(observations, target = 10.0, k = 0.25, h = 4.0)
+ * result.sPlus       // non-negative running upper CUSUM values
+ * result.sMinus      // non-negative running lower CUSUM values
+ * result.alarmIndex  // zero-based index where C⁺ > H first, or -1 if never
+ * ```
+ *
+ * References: Page (1954), "Continuous Inspection Schemes"; Montgomery, "Introduction
+ * to Statistical Quality Control" (7th ed.), §9.1.1.
+ *
+ * @param observations the sequence of individual measurements to monitor. Must contain
+ * at least 1 element.
+ * @param target the reference mean μ₀ to monitor against. Any finite value is allowed.
+ * @param k the allowance (slack) value K, half the magnitude of the shift to detect.
+ * Must be non-negative. Typically chosen as ≈ 0.5σ of the in-control process.
+ * @param h the decision interval H above which the CUSUM signals an out-of-control
+ * condition. Must be strictly positive. Typically chosen as 4σ or 5σ.
+ * @return a [CusumResult] with the full C⁺ and C⁻ series and the index of the first alarm.
+ * @throws InsufficientDataException if [observations] is empty.
+ * @throws InvalidParameterException if [k] is negative or [h] is non-positive.
+ * @see CusumResult
+ * @see xBarRChart
+ * @see xBarSChart
+ */
+public fun cusum(
+    observations: DoubleArray,
+    target: Double,
+    k: Double,
+    h: Double,
+): CusumResult {
+    if (observations.isEmpty()) throw InsufficientDataException(
+        "CUSUM requires at least 1 observation, got 0"
+    )
+    if (k < 0.0) throw InvalidParameterException("allowance k must be non-negative, got $k")
+    if (h <= 0.0) throw InvalidParameterException("decision interval h must be positive, got $h")
+
+    // Tabular two-sided CUSUM (Page 1954; Montgomery "Introduction to Statistical Quality
+    // Control" 7th ed., §9.1.1):
+    //   C⁺ᵢ = max(0, C⁺ᵢ₋₁ + (xᵢ − μ₀ − K))
+    //   C⁻ᵢ = max(0, C⁻ᵢ₋₁ + (μ₀ − K − xᵢ))
+    // Alarm fires when C⁺ᵢ > H or C⁻ᵢ > H.
+    val n = observations.size
+    val sPlus = DoubleArray(n)
+    val sMinus = DoubleArray(n)
+    var prevPlus = 0.0
+    var prevMinus = 0.0
+    var alarmIndex = -1
+
+    for (i in 0 until n) {
+        val x = observations[i]
+        val cPlus = maxOf(0.0, prevPlus + (x - target - k))
+        val cMinus = maxOf(0.0, prevMinus + (target - k - x))
+        sPlus[i] = cPlus
+        sMinus[i] = cMinus
+        if (alarmIndex == -1 && (cPlus > h || cMinus > h)) {
+            alarmIndex = i
+        }
+        prevPlus = cPlus
+        prevMinus = cMinus
+    }
+
+    return CusumResult(sPlus = sPlus, sMinus = sMinus, alarmIndex = alarmIndex)
+}
+
+/**
+ * Computes a two-sided tabular CUSUM control chart for an [Iterable] of observations.
+ *
+ * Convenience overload that collects [observations] into a `DoubleArray` and delegates
+ * to the primary [cusum] function. See [cusum] for the full description of the
+ * algorithm, parameter guidance, and references.
+ *
+ * ### Example:
+ * ```kotlin
+ * val observations: List<Double> = listOf(10.0, 10.1, 9.9, 10.0, 10.2, 10.5, 10.7, 10.9, 11.1)
+ * val result = cusum(observations, target = 10.0, k = 0.25, h = 4.0)
+ * result.alarmIndex  // zero-based index of first alarm, or -1 if never
+ * ```
+ *
+ * @param observations the sequence of individual measurements to monitor. Must contain
+ * at least 1 element.
+ * @param target the reference mean μ₀ to monitor against. Any finite value is allowed.
+ * @param k the allowance (slack) value K. Must be non-negative. Typically ≈ 0.5σ.
+ * @param h the decision interval H. Must be strictly positive. Typically 4σ or 5σ.
+ * @return a [CusumResult] with the full C⁺ and C⁻ series and the index of the first alarm.
+ * @throws InsufficientDataException if [observations] is empty.
+ * @throws InvalidParameterException if [k] is negative or [h] is non-positive.
+ * @see cusum
+ * @see CusumResult
+ */
+public fun cusum(
+    observations: Iterable<Double>,
+    target: Double,
+    k: Double,
+    h: Double,
+): CusumResult = cusum(observations.toList().toDoubleArray(), target, k, h)
+
+/**
+ * Computes a two-sided tabular CUSUM control chart for a [Sequence] of observations.
+ *
+ * Convenience overload that collects [observations] into a `DoubleArray` and delegates
+ * to the primary [cusum] function. See [cusum] for the full description of the
+ * algorithm, parameter guidance, and references.
+ *
+ * ### Example:
+ * ```kotlin
+ * val observations: Sequence<Double> = sequenceOf(10.0, 10.1, 9.9, 10.0, 10.2, 10.5, 10.7, 10.9, 11.1)
+ * val result = cusum(observations, target = 10.0, k = 0.25, h = 4.0)
+ * result.alarmIndex  // zero-based index of first alarm, or -1 if never
+ * ```
+ *
+ * @param observations the sequence of individual measurements to monitor. Must contain
+ * at least 1 element.
+ * @param target the reference mean μ₀ to monitor against. Any finite value is allowed.
+ * @param k the allowance (slack) value K. Must be non-negative. Typically ≈ 0.5σ.
+ * @param h the decision interval H. Must be strictly positive. Typically 4σ or 5σ.
+ * @return a [CusumResult] with the full C⁺ and C⁻ series and the index of the first alarm.
+ * @throws InsufficientDataException if [observations] is empty.
+ * @throws InvalidParameterException if [k] is negative or [h] is non-positive.
+ * @see cusum
+ * @see CusumResult
+ */
+public fun cusum(
+    observations: Sequence<Double>,
+    target: Double,
+    k: Double,
+    h: Double,
+): CusumResult = cusum(observations.toList().toDoubleArray(), target, k, h)
+
 // ── Validation ─────────────────────────────────────────────────────────────────
 
 private fun validateSubgroups(subgroups: List<DoubleArray>) {

--- a/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/ControlChart.kt
+++ b/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/ControlChart.kt
@@ -325,6 +325,10 @@ public data class CusumResult(
         result = 31 * result + alarmIndex
         return result
     }
+
+    override fun toString(): String =
+        "CusumResult(sPlus=${sPlus.contentToString()}, sMinus=${sMinus.contentToString()}, " +
+            "alarmIndex=$alarmIndex)"
 }
 
 /**

--- a/kstats-core/src/commonTest/kotlin/org/oremif/kstats/descriptive/ControlChartTest.kt
+++ b/kstats-core/src/commonTest/kotlin/org/oremif/kstats/descriptive/ControlChartTest.kt
@@ -1555,4 +1555,20 @@ internal class ControlChartTest {
         assertEquals(result.sMinus.size, sMinus.size, "sMinus via destructuring")
         assertEquals(result.alarmIndex, alarmIndex, "alarmIndex via destructuring")
     }
+
+    @Test
+    fun testCusumResultToStringRendersArrayContents() {
+        // toString must use contentToString() for DoubleArray fields — the default
+        // data-class toString would print `[D@<hash>` which is useless for diagnostics.
+        val result = CusumResult(
+            sPlus = doubleArrayOf(0.0, 0.1, 0.3),
+            sMinus = doubleArrayOf(0.0, 0.0, 0.05),
+            alarmIndex = -1,
+        )
+        val s = result.toString()
+        assertTrue(s.contains("sPlus=[0.0, 0.1, 0.3]"), "toString should render sPlus elements, got: $s")
+        assertTrue(s.contains("sMinus=[0.0, 0.0, 0.05]"), "toString should render sMinus elements, got: $s")
+        assertTrue(s.contains("alarmIndex=-1"), "toString should render alarmIndex, got: $s")
+        assertTrue(!s.contains("[D@"), "toString must not leak default array identity, got: $s")
+    }
 }

--- a/kstats-core/src/commonTest/kotlin/org/oremif/kstats/descriptive/ControlChartTest.kt
+++ b/kstats-core/src/commonTest/kotlin/org/oremif/kstats/descriptive/ControlChartTest.kt
@@ -944,4 +944,615 @@ internal class ControlChartTest {
         assertEquals(45.0, result.lcl, 0.0)
         assertEquals(sChart, result.sChart)
     }
+
+    // ===== cusum: Basic correctness =====
+
+    @Test
+    fun testCusumIssueExample() {
+        // Hand-computed CUSUM from issue #36 example:
+        // observations = [10.1, 10.3, 10.5, 10.8, 11.0, 11.3], target=10.0, k=0.25, h=4.0
+        // C+[0] = max(0, 0 + (10.1 - 10.0 - 0.25)) = max(0, -0.15) = 0
+        // C+[1] = max(0, 0 + (10.3 - 10.25)) = 0.05
+        // C+[2] = max(0, 0.05 + (10.5 - 10.25)) = 0.30
+        // C+[3] = max(0, 0.30 + (10.8 - 10.25)) = 0.85
+        // C+[4] = max(0, 0.85 + (11.0 - 10.25)) = 1.60
+        // C+[5] = max(0, 1.60 + (11.3 - 10.25)) = 2.65
+        // C-[i] = 0 for all i (all observations above target - k = 9.75)
+        // alarmIndex = -1 (C+ never exceeds 4.0)
+        val obs = doubleArrayOf(10.1, 10.3, 10.5, 10.8, 11.0, 11.3)
+        val result = cusum(obs, target = 10.0, k = 0.25, h = 4.0)
+
+        // numpy: manually computed as above
+        assertEquals(0.0, result.sPlus[0], tol, "sPlus[0]")
+        assertEquals(0.05, result.sPlus[1], tol, "sPlus[1]")
+        assertEquals(0.30, result.sPlus[2], tol, "sPlus[2]")
+        assertEquals(0.85, result.sPlus[3], tol, "sPlus[3]")
+        assertEquals(1.60, result.sPlus[4], tol, "sPlus[4]")
+        assertEquals(2.65, result.sPlus[5], tol, "sPlus[5]")
+        for (i in obs.indices) {
+            assertEquals(0.0, result.sMinus[i], tol, "sMinus[$i]")
+        }
+        assertEquals(-1, result.alarmIndex, "alarmIndex")
+    }
+
+    @Test
+    fun testCusumMontgomeryTable92() {
+        // Montgomery "Introduction to Statistical Quality Control" (7th ed.), §9.1.1, Table 9.2, p.416
+        // 30 observations from a process with mu_0=10, sigma=1, monitored with K=0.5, H=5
+        // The process shifts upward around observation 20; CUSUM detects the shift
+        // numpy: canonical 30-observation Montgomery CUSUM example
+        val obs = doubleArrayOf(
+            9.45, 7.99, 9.29, 11.66, 12.16, 10.18, 8.04, 11.46, 9.20, 10.34,
+            9.03, 11.47, 10.51, 9.40, 10.08, 9.37, 10.62, 10.31, 8.52, 10.84,
+            10.90, 9.33, 12.29, 11.50, 10.60, 11.08, 10.38, 11.62, 11.31, 10.52
+        )
+        val result = cusum(obs, target = 10.0, k = 0.5, h = 5.0)
+
+        // numpy: last values should be sPlus[29] ≈ 5.30, sMinus[29] ≈ 0
+        assertEquals(5.30, result.sPlus[29], tol, "sPlus[29]")
+        assertEquals(0.0, result.sMinus[29], tol, "sMinus[29]")
+        // numpy: alarm at i=28 (sPlus[28]=5.28 > 5, first violation is actually at 28)
+        assertEquals(28, result.alarmIndex, "alarmIndex (Montgomery example)")
+
+        // numpy: spot-check a few mid-series values
+        assertEquals(1.16, result.sPlus[3], tol, "sPlus[3]")
+        assertEquals(2.82, result.sPlus[4], tol, "sPlus[4]")
+        assertEquals(1.56, result.sMinus[1], tol, "sMinus[1]")
+        assertEquals(1.77, result.sMinus[2], tol, "sMinus[2]")
+    }
+
+    @Test
+    fun testCusumNoAlarm() {
+        // Observations all near target, variations well below h
+        // numpy: cusum([10.05, 9.95, 10.03, 9.97, 10.02, 9.98], 10.0, 0.5, 5.0)
+        val obs = doubleArrayOf(10.05, 9.95, 10.03, 9.97, 10.02, 9.98)
+        val result = cusum(obs, target = 10.0, k = 0.5, h = 5.0)
+
+        for (i in obs.indices) {
+            assertEquals(0.0, result.sPlus[i], tol, "sPlus[$i] near target")
+            assertEquals(0.0, result.sMinus[i], tol, "sMinus[$i] near target")
+        }
+        assertEquals(-1, result.alarmIndex, "alarmIndex should be -1")
+    }
+
+    @Test
+    fun testCusumUpperAlarm() {
+        // Upward drift: [10.2, 10.4, ..., 12.0]; alarm at i=6 (sPlus=3.5>3)
+        // numpy: cusum([10.2, 10.4, 10.6, 10.9, 11.2, 11.5, 11.8, 12.0], 10.0, 0.5, 3.0)
+        val obs = doubleArrayOf(10.2, 10.4, 10.6, 10.9, 11.2, 11.5, 11.8, 12.0)
+        val result = cusum(obs, target = 10.0, k = 0.5, h = 3.0)
+
+        // numpy: sPlus=[0, 0, 0.1, 0.5, 1.2, 2.2, 3.5, 5.0]
+        assertEquals(0.0, result.sPlus[0], tol, "sPlus[0]")
+        assertEquals(0.0, result.sPlus[1], tol, "sPlus[1]")
+        assertEquals(0.1, result.sPlus[2], tol, "sPlus[2]")
+        assertEquals(0.5, result.sPlus[3], tol, "sPlus[3]")
+        assertEquals(1.2, result.sPlus[4], tol, "sPlus[4]")
+        assertEquals(2.2, result.sPlus[5], tol, "sPlus[5]")
+        assertEquals(3.5, result.sPlus[6], tol, "sPlus[6]")
+        assertEquals(5.0, result.sPlus[7], tol, "sPlus[7]")
+        for (i in obs.indices) {
+            assertEquals(0.0, result.sMinus[i], tol, "sMinus[$i]")
+        }
+        assertEquals(6, result.alarmIndex, "alarmIndex should be 6 (first sPlus>3)")
+    }
+
+    @Test
+    fun testCusumLowerAlarm() {
+        // Downward drift: mirror of upper-alarm case, swaps sPlus and sMinus
+        // numpy: cusum([9.8, 9.6, 9.4, 9.1, 8.8, 8.5, 8.2, 8.0], 10.0, 0.5, 3.0)
+        val obs = doubleArrayOf(9.8, 9.6, 9.4, 9.1, 8.8, 8.5, 8.2, 8.0)
+        val result = cusum(obs, target = 10.0, k = 0.5, h = 3.0)
+
+        // numpy: sMinus=[0, 0, 0.1, 0.5, 1.2, 2.2, 3.5, 5.0]
+        assertEquals(0.0, result.sMinus[0], tol, "sMinus[0]")
+        assertEquals(0.0, result.sMinus[1], tol, "sMinus[1]")
+        assertEquals(0.1, result.sMinus[2], tol, "sMinus[2]")
+        assertEquals(0.5, result.sMinus[3], tol, "sMinus[3]")
+        assertEquals(1.2, result.sMinus[4], tol, "sMinus[4]")
+        assertEquals(2.2, result.sMinus[5], tol, "sMinus[5]")
+        assertEquals(3.5, result.sMinus[6], tol, "sMinus[6]")
+        assertEquals(5.0, result.sMinus[7], tol, "sMinus[7]")
+        for (i in obs.indices) {
+            assertEquals(0.0, result.sPlus[i], tol, "sPlus[$i]")
+        }
+        assertEquals(6, result.alarmIndex, "alarmIndex should be 6 (first sMinus>3)")
+    }
+
+    @Test
+    fun testCusumAlarmAtFirstObservation() {
+        // Very strong upward shift at i=0: x-target-k = 20-10-0.5 = 9.5 > 5
+        // numpy: cusum([20.0, 10.0, 10.0], 10.0, 0.5, 5.0)
+        val obs = doubleArrayOf(20.0, 10.0, 10.0)
+        val result = cusum(obs, target = 10.0, k = 0.5, h = 5.0)
+
+        // numpy: sPlus=[9.5, 9.0, 8.5]; sPlus[0]=9.5 > h=5
+        assertEquals(9.5, result.sPlus[0], tol, "sPlus[0]")
+        assertEquals(9.0, result.sPlus[1], tol, "sPlus[1]")
+        assertEquals(8.5, result.sPlus[2], tol, "sPlus[2]")
+        assertEquals(0, result.alarmIndex, "alarmIndex should be 0")
+    }
+
+    // ===== cusum: Edge cases =====
+
+    @Test
+    fun testCusumSingleObservationAboveTarget() {
+        // Single observation with x > target + k
+        // numpy: sPlus[0] = max(0, 12-10-0.5) = 1.5, sMinus[0] = 0
+        val result = cusum(doubleArrayOf(12.0), target = 10.0, k = 0.5, h = 5.0)
+
+        assertEquals(1, result.sPlus.size, "sPlus.size")
+        assertEquals(1, result.sMinus.size, "sMinus.size")
+        assertEquals(1.5, result.sPlus[0], tol, "sPlus[0]")
+        assertEquals(0.0, result.sMinus[0], tol, "sMinus[0]")
+        assertEquals(-1, result.alarmIndex, "no alarm (1.5 < 5.0)")
+    }
+
+    @Test
+    fun testCusumSingleObservationBelowTarget() {
+        // Single observation with x < target - k
+        // numpy: sPlus[0] = 0, sMinus[0] = max(0, 10-0.5-7) = 2.5
+        val result = cusum(doubleArrayOf(7.0), target = 10.0, k = 0.5, h = 5.0)
+
+        assertEquals(0.0, result.sPlus[0], tol, "sPlus[0]")
+        assertEquals(2.5, result.sMinus[0], tol, "sMinus[0]")
+        assertEquals(-1, result.alarmIndex, "no alarm (2.5 < 5.0)")
+    }
+
+    @Test
+    fun testCusumSingleObservationAtTarget() {
+        // Single observation equal to target: both zero
+        val result = cusum(doubleArrayOf(10.0), target = 10.0, k = 0.5, h = 5.0)
+
+        assertEquals(0.0, result.sPlus[0], tol, "sPlus[0]")
+        assertEquals(0.0, result.sMinus[0], tol, "sMinus[0]")
+        assertEquals(-1, result.alarmIndex, "no alarm")
+    }
+
+    @Test
+    fun testCusumAllObservationsEqualToTarget() {
+        // All observations == target => both sPlus and sMinus are all zeros
+        val obs = DoubleArray(10) { 5.0 }
+        val result = cusum(obs, target = 5.0, k = 0.5, h = 3.0)
+
+        for (i in obs.indices) {
+            assertEquals(0.0, result.sPlus[i], tol, "sPlus[$i] should be 0")
+            assertEquals(0.0, result.sMinus[i], tol, "sMinus[$i] should be 0")
+        }
+        assertEquals(-1, result.alarmIndex, "no alarm when all equal to target")
+    }
+
+    @Test
+    fun testCusumKEqualsZero() {
+        // k=0 (zero allowance): pure cumulative sum of deviations from target
+        // With target=0, sPlus is cumulative positive excursions, sMinus of negative
+        // numpy: cusum([1, -0.5, 2, -1.5, 3], 0, 0, 100)
+        val obs = doubleArrayOf(1.0, -0.5, 2.0, -1.5, 3.0)
+        val result = cusum(obs, target = 0.0, k = 0.0, h = 100.0)
+
+        // numpy: sPlus=[1, 0.5, 2.5, 1, 4]; sMinus=[0, 0.5, 0, 1.5, 0]
+        val expectedPlus = doubleArrayOf(1.0, 0.5, 2.5, 1.0, 4.0)
+        val expectedMinus = doubleArrayOf(0.0, 0.5, 0.0, 1.5, 0.0)
+        for (i in obs.indices) {
+            assertEquals(expectedPlus[i], result.sPlus[i], tol, "sPlus[$i]")
+            assertEquals(expectedMinus[i], result.sMinus[i], tol, "sMinus[$i]")
+        }
+        assertEquals(-1, result.alarmIndex, "no alarm with h=100")
+    }
+
+    @Test
+    fun testCusumVeryLargeH() {
+        // Very large h: never triggers alarm regardless of data
+        val obs = doubleArrayOf(100.0, 200.0, 300.0, 400.0, 500.0)
+        val result = cusum(obs, target = 0.0, k = 0.5, h = 1e100)
+
+        assertEquals(-1, result.alarmIndex, "very large h => no alarm")
+        // sPlus should be cumulative (no capping)
+        assertTrue(result.sPlus[4] > 1000.0, "sPlus should accumulate")
+    }
+
+    @Test
+    fun testCusumVerySmallH() {
+        // Very small h: alarm triggers at first deviation beyond k
+        // numpy: cusum([10.5, 10.0], 10.0, 0.25, 0.1) => sPlus[0]=0.25, alarm at 0
+        val obs = doubleArrayOf(10.5, 10.0)
+        val result = cusum(obs, target = 10.0, k = 0.25, h = 0.1)
+
+        assertEquals(0.25, result.sPlus[0], tol, "sPlus[0]")
+        assertEquals(0, result.alarmIndex, "alarm at 0 with tiny h")
+    }
+
+    @Test
+    fun testCusumIterableOverload() {
+        // Iterable overload should give identical result to DoubleArray overload
+        val array = doubleArrayOf(10.1, 10.3, 10.5, 10.8, 11.0, 11.3)
+        val list: Iterable<Double> = array.toList()
+        val expected = cusum(array, target = 10.0, k = 0.25, h = 4.0)
+        val actual = cusum(list, target = 10.0, k = 0.25, h = 4.0)
+
+        assertEquals(expected, actual, "Iterable overload should match DoubleArray overload")
+    }
+
+    @Test
+    fun testCusumSequenceOverload() {
+        // Sequence overload should give identical result to DoubleArray overload
+        val array = doubleArrayOf(10.1, 10.3, 10.5, 10.8, 11.0, 11.3)
+        val seq: Sequence<Double> = array.asSequence()
+        val expected = cusum(array, target = 10.0, k = 0.25, h = 4.0)
+        val actual = cusum(seq, target = 10.0, k = 0.25, h = 4.0)
+
+        assertEquals(expected, actual, "Sequence overload should match DoubleArray overload")
+    }
+
+    @Test
+    fun testCusumResultArrayLengths() {
+        // sPlus and sMinus arrays have same length as input
+        val obs = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
+        val result = cusum(obs, target = 3.0, k = 0.5, h = 10.0)
+        assertEquals(obs.size, result.sPlus.size, "sPlus.size")
+        assertEquals(obs.size, result.sMinus.size, "sMinus.size")
+    }
+
+    // ===== cusum: Degenerate input =====
+
+    @Test
+    fun testCusumEmptyArray() {
+        assertFailsWith<InsufficientDataException> {
+            cusum(doubleArrayOf(), target = 0.0, k = 0.5, h = 5.0)
+        }
+    }
+
+    @Test
+    fun testCusumEmptyIterable() {
+        assertFailsWith<InsufficientDataException> {
+            cusum(emptyList<Double>(), target = 0.0, k = 0.5, h = 5.0)
+        }
+    }
+
+    @Test
+    fun testCusumEmptySequence() {
+        assertFailsWith<InsufficientDataException> {
+            cusum(emptySequence<Double>(), target = 0.0, k = 0.5, h = 5.0)
+        }
+    }
+
+    @Test
+    fun testCusumNegativeK() {
+        assertFailsWith<InvalidParameterException> {
+            cusum(doubleArrayOf(1.0, 2.0, 3.0), target = 0.0, k = -0.1, h = 5.0)
+        }
+    }
+
+    @Test
+    fun testCusumNegativeKIterable() {
+        assertFailsWith<InvalidParameterException> {
+            cusum(listOf(1.0, 2.0, 3.0), target = 0.0, k = -0.5, h = 5.0)
+        }
+    }
+
+    @Test
+    fun testCusumNegativeKSequence() {
+        assertFailsWith<InvalidParameterException> {
+            cusum(sequenceOf(1.0, 2.0, 3.0), target = 0.0, k = -1.0, h = 5.0)
+        }
+    }
+
+    @Test
+    fun testCusumZeroH() {
+        assertFailsWith<InvalidParameterException> {
+            cusum(doubleArrayOf(1.0, 2.0, 3.0), target = 0.0, k = 0.5, h = 0.0)
+        }
+    }
+
+    @Test
+    fun testCusumNegativeH() {
+        assertFailsWith<InvalidParameterException> {
+            cusum(doubleArrayOf(1.0, 2.0, 3.0), target = 0.0, k = 0.5, h = -1.0)
+        }
+    }
+
+    @Test
+    fun testCusumNegativeHIterable() {
+        assertFailsWith<InvalidParameterException> {
+            cusum(listOf(1.0, 2.0, 3.0), target = 0.0, k = 0.5, h = -0.1)
+        }
+    }
+
+    @Test
+    fun testCusumNegativeHSequence() {
+        assertFailsWith<InvalidParameterException> {
+            cusum(sequenceOf(1.0, 2.0, 3.0), target = 0.0, k = 0.5, h = -5.0)
+        }
+    }
+
+    // ===== cusum: Non-finite input =====
+
+    @Test
+    fun testCusumNaNInObservations() {
+        // NaN propagates from its index onward (IEEE 754)
+        val obs = doubleArrayOf(10.0, 10.1, Double.NaN, 10.3, 10.4)
+        val result = cusum(obs, target = 10.0, k = 0.5, h = 5.0)
+
+        // Before NaN: normal computation
+        assertEquals(0.0, result.sPlus[0], tol, "sPlus[0] before NaN")
+        assertEquals(0.0, result.sPlus[1], tol, "sPlus[1] before NaN")
+        // NaN index and beyond propagate NaN
+        assertTrue(result.sPlus[2].isNaN(), "sPlus[2] should be NaN")
+        assertTrue(result.sMinus[2].isNaN(), "sMinus[2] should be NaN")
+        // Subsequent indices remain NaN due to running accumulator
+        assertTrue(result.sPlus[3].isNaN(), "sPlus[3] propagates NaN")
+        assertTrue(result.sPlus[4].isNaN(), "sPlus[4] propagates NaN")
+    }
+
+    @Test
+    fun testCusumPositiveInfinityInObservations() {
+        // +Infinity in observations: result is non-finite from that index
+        val obs = doubleArrayOf(10.0, Double.POSITIVE_INFINITY, 10.0)
+        val result = cusum(obs, target = 10.0, k = 0.5, h = 5.0)
+
+        assertTrue(!result.sPlus[1].isFinite(), "sPlus[1] with +Infinity should be non-finite")
+    }
+
+    @Test
+    fun testCusumNegativeInfinityInObservations() {
+        // -Infinity in observations: result is non-finite from that index
+        val obs = doubleArrayOf(10.0, Double.NEGATIVE_INFINITY, 10.0)
+        val result = cusum(obs, target = 10.0, k = 0.5, h = 5.0)
+
+        assertTrue(!result.sMinus[1].isFinite(), "sMinus[1] with -Infinity should be non-finite")
+    }
+
+    @Test
+    fun testCusumNaNTargetDoesNotThrow() {
+        // NaN passes validation (per project convention); results become NaN
+        val obs = doubleArrayOf(1.0, 2.0, 3.0)
+        val result = cusum(obs, target = Double.NaN, k = 0.5, h = 5.0)
+
+        for (i in obs.indices) {
+            assertTrue(result.sPlus[i].isNaN(), "sPlus[$i] should be NaN with NaN target")
+            assertTrue(result.sMinus[i].isNaN(), "sMinus[$i] should be NaN with NaN target")
+        }
+    }
+
+    @Test
+    fun testCusumNaNKDoesNotThrow() {
+        // NaN k passes validation (NaN < 0.0 is false per IEEE 754); results become NaN
+        val obs = doubleArrayOf(1.0, 2.0, 3.0)
+        val result = cusum(obs, target = 1.0, k = Double.NaN, h = 5.0)
+
+        for (i in obs.indices) {
+            assertTrue(result.sPlus[i].isNaN(), "sPlus[$i] should be NaN with NaN k")
+            assertTrue(result.sMinus[i].isNaN(), "sMinus[$i] should be NaN with NaN k")
+        }
+    }
+
+    @Test
+    fun testCusumNaNHDoesNotThrow() {
+        // NaN h passes validation (NaN <= 0.0 is false per IEEE 754)
+        // The alarm comparison `cPlus > h` with NaN h is always false, so no alarm
+        val obs = doubleArrayOf(1.0, 2.0, 3.0)
+        val result = cusum(obs, target = 1.0, k = 0.5, h = Double.NaN)
+
+        // Computation proceeds normally; no alarm triggers because x > NaN is always false
+        assertEquals(-1, result.alarmIndex, "NaN h produces no alarm")
+    }
+
+    // ===== cusum: Property-based =====
+
+    @Test
+    fun testCusumNonNegativeForFiniteInput() {
+        // sPlus and sMinus are always >= 0 for finite inputs (since max(0, ·))
+        val obs = doubleArrayOf(9.0, 11.0, 8.5, 12.0, 7.5, 13.0, 10.0, 9.0, 11.5, 8.0)
+        val result = cusum(obs, target = 10.0, k = 0.3, h = 4.0)
+
+        for (i in obs.indices) {
+            assertTrue(result.sPlus[i] >= 0.0, "sPlus[$i]=${result.sPlus[i]} should be >= 0")
+            assertTrue(result.sMinus[i] >= 0.0, "sMinus[$i]=${result.sMinus[i]} should be >= 0")
+        }
+    }
+
+    @Test
+    fun testCusumTranslationInvariance() {
+        // Shifting all observations AND target by the same constant gives identical sPlus/sMinus
+        val obs = doubleArrayOf(10.1, 10.3, 10.5, 10.8, 11.0, 11.3)
+        val shift = 1000.0
+        val shiftedObs = DoubleArray(obs.size) { obs[it] + shift }
+
+        val original = cusum(obs, target = 10.0, k = 0.25, h = 4.0)
+        val shifted = cusum(shiftedObs, target = 10.0 + shift, k = 0.25, h = 4.0)
+
+        for (i in obs.indices) {
+            assertEquals(original.sPlus[i], shifted.sPlus[i], 1e-7, "sPlus[$i] translation invariance")
+            assertEquals(original.sMinus[i], shifted.sMinus[i], 1e-7, "sMinus[$i] translation invariance")
+        }
+        assertEquals(original.alarmIndex, shifted.alarmIndex, "alarmIndex unchanged by translation")
+    }
+
+    @Test
+    fun testCusumSymmetryByNegation() {
+        // Negating observations AND target swaps sPlus and sMinus
+        val obs = doubleArrayOf(10.2, 10.4, 10.6, 10.9, 11.2, 11.5, 11.8, 12.0)
+        val negObs = DoubleArray(obs.size) { -obs[it] }
+
+        val original = cusum(obs, target = 10.0, k = 0.5, h = 3.0)
+        val negated = cusum(negObs, target = -10.0, k = 0.5, h = 3.0)
+
+        for (i in obs.indices) {
+            assertEquals(original.sPlus[i], negated.sMinus[i], tol, "sPlus[$i] <-> sMinus[$i] under negation")
+            assertEquals(original.sMinus[i], negated.sPlus[i], tol, "sMinus[$i] <-> sPlus[$i] under negation")
+        }
+        assertEquals(original.alarmIndex, negated.alarmIndex, "alarmIndex unchanged by negation")
+    }
+
+    @Test
+    fun testCusumSingleObservationFormula() {
+        // For n=1: sPlus[0] = max(0, x-target-k), sMinus[0] = max(0, target-k-x)
+        val target = 10.0
+        val k = 0.5
+        val h = 100.0 // large h to avoid alarm
+
+        for (x in listOf(5.0, 9.0, 10.0, 10.25, 11.0, 15.0)) {
+            val result = cusum(doubleArrayOf(x), target = target, k = k, h = h)
+            val expectedPlus = maxOf(0.0, x - target - k)
+            val expectedMinus = maxOf(0.0, target - k - x)
+            assertEquals(expectedPlus, result.sPlus[0], tol, "sPlus[0] for x=$x")
+            assertEquals(expectedMinus, result.sMinus[0], tol, "sMinus[0] for x=$x")
+        }
+    }
+
+    @Test
+    fun testCusumArrayLengthProperty() {
+        // For various input sizes, output arrays match input length
+        for (n in listOf(1, 2, 5, 10, 50, 100)) {
+            val obs = DoubleArray(n) { (it + 1).toDouble() }
+            val result = cusum(obs, target = 5.0, k = 0.5, h = 100.0)
+            assertEquals(n, result.sPlus.size, "sPlus.size for n=$n")
+            assertEquals(n, result.sMinus.size, "sMinus.size for n=$n")
+        }
+    }
+
+    @Test
+    fun testCusumLargeHNoAlarm() {
+        // If h is very large, alarmIndex = -1 regardless of data
+        val obs = doubleArrayOf(100.0, -200.0, 300.0, -400.0)
+        val result = cusum(obs, target = 0.0, k = 0.5, h = 1e308)
+
+        assertEquals(-1, result.alarmIndex, "very large h => no alarm")
+    }
+
+    @Test
+    fun testCusumAlarmIndexIsFirst() {
+        // alarmIndex should be the earliest index where sPlus>h or sMinus>h
+        val obs = doubleArrayOf(10.2, 10.4, 10.6, 10.9, 11.2, 11.5, 11.8, 12.0)
+        val result = cusum(obs, target = 10.0, k = 0.5, h = 3.0)
+
+        val alarm = result.alarmIndex
+        assertTrue(alarm >= 0, "alarm should fire")
+        // No earlier index should have fired
+        for (i in 0 until alarm) {
+            assertTrue(
+                result.sPlus[i] <= 3.0 && result.sMinus[i] <= 3.0,
+                "Index $i before alarm: sPlus=${result.sPlus[i]}, sMinus=${result.sMinus[i]}"
+            )
+        }
+        // At the alarm index, at least one exceeds h
+        assertTrue(
+            result.sPlus[alarm] > 3.0 || result.sMinus[alarm] > 3.0,
+            "At alarm: sPlus=${result.sPlus[alarm]}, sMinus=${result.sMinus[alarm]}"
+        )
+    }
+
+    @Test
+    fun testCusumRecursiveDefinition() {
+        // Property: for all i >= 1,
+        //   sPlus[i] == max(0, sPlus[i-1] + (obs[i] - target - k))
+        //   sMinus[i] == max(0, sMinus[i-1] + (target - k - obs[i]))
+        val obs = doubleArrayOf(10.1, 10.3, 10.5, 10.8, 11.0, 11.3, 9.5, 9.2, 10.7, 11.5)
+        val target = 10.0
+        val k = 0.25
+        val result = cusum(obs, target = target, k = k, h = 10.0)
+
+        for (i in 1 until obs.size) {
+            val expectedPlus = maxOf(0.0, result.sPlus[i - 1] + (obs[i] - target - k))
+            val expectedMinus = maxOf(0.0, result.sMinus[i - 1] + (target - k - obs[i]))
+            assertEquals(expectedPlus, result.sPlus[i], tol, "sPlus recursion at i=$i")
+            assertEquals(expectedMinus, result.sMinus[i], tol, "sMinus recursion at i=$i")
+        }
+    }
+
+    // ===== CusumResult: data class =====
+
+    @Test
+    fun testCusumResultEquality() {
+        // Two identical calls produce equal results (via equals/hashCode)
+        val obs = doubleArrayOf(10.1, 10.3, 10.5, 10.8, 11.0, 11.3)
+        val r1 = cusum(obs, target = 10.0, k = 0.25, h = 4.0)
+        val r2 = cusum(obs, target = 10.0, k = 0.25, h = 4.0)
+
+        assertEquals(r1, r2, "Same input should produce equal CusumResult")
+        assertEquals(r1.hashCode(), r2.hashCode(), "Equal results should have equal hashCode")
+    }
+
+    @Test
+    fun testCusumResultEqualityDifferentInstances() {
+        // equals uses contentEquals, so different array instances with same values are equal
+        val r1 = CusumResult(
+            sPlus = doubleArrayOf(0.0, 0.1, 0.3),
+            sMinus = doubleArrayOf(0.0, 0.0, 0.0),
+            alarmIndex = -1,
+        )
+        val r2 = CusumResult(
+            sPlus = doubleArrayOf(0.0, 0.1, 0.3),
+            sMinus = doubleArrayOf(0.0, 0.0, 0.0),
+            alarmIndex = -1,
+        )
+        assertTrue(r1 !== r2, "Different instances")
+        assertEquals(r1, r2, "Different array instances with same content should be equal")
+        assertEquals(r1.hashCode(), r2.hashCode(), "hashCode consistent with equals")
+    }
+
+    @Test
+    fun testCusumResultInequality() {
+        // Different alarmIndex => not equal
+        val r1 = CusumResult(
+            sPlus = doubleArrayOf(0.0, 0.1),
+            sMinus = doubleArrayOf(0.0, 0.0),
+            alarmIndex = -1,
+        )
+        val r2 = CusumResult(
+            sPlus = doubleArrayOf(0.0, 0.1),
+            sMinus = doubleArrayOf(0.0, 0.0),
+            alarmIndex = 1,
+        )
+        assertTrue(r1 != r2, "Different alarmIndex => not equal")
+
+        // Different sPlus contents => not equal
+        val r3 = CusumResult(
+            sPlus = doubleArrayOf(0.0, 0.2),
+            sMinus = doubleArrayOf(0.0, 0.0),
+            alarmIndex = -1,
+        )
+        assertTrue(r1 != r3, "Different sPlus => not equal")
+
+        // Different sMinus contents => not equal
+        val r4 = CusumResult(
+            sPlus = doubleArrayOf(0.0, 0.1),
+            sMinus = doubleArrayOf(0.1, 0.0),
+            alarmIndex = -1,
+        )
+        assertTrue(r1 != r4, "Different sMinus => not equal")
+    }
+
+    @Test
+    fun testCusumResultEqualsSelf() {
+        val r = CusumResult(
+            sPlus = doubleArrayOf(0.0, 0.1, 0.3),
+            sMinus = doubleArrayOf(0.0, 0.0, 0.0),
+            alarmIndex = -1,
+        )
+        assertEquals(r, r, "equals with self")
+    }
+
+    @Test
+    fun testCusumResultEqualsNonCusumResult() {
+        val r = CusumResult(
+            sPlus = doubleArrayOf(0.0),
+            sMinus = doubleArrayOf(0.0),
+            alarmIndex = -1,
+        )
+        assertTrue(!r.equals("not a CusumResult"), "equals returns false for non-CusumResult")
+        assertTrue(!r.equals(null), "equals returns false for null")
+    }
+
+    @Test
+    fun testCusumResultDestructuring() {
+        // componentN (destructuring) works on the data class
+        val obs = doubleArrayOf(10.1, 10.3, 10.5)
+        val result = cusum(obs, target = 10.0, k = 0.25, h = 4.0)
+        val (sPlus, sMinus, alarmIndex) = result
+
+        assertEquals(result.sPlus.size, sPlus.size, "sPlus via destructuring")
+        assertEquals(result.sMinus.size, sMinus.size, "sMinus via destructuring")
+        assertEquals(result.alarmIndex, alarmIndex, "alarmIndex via destructuring")
+    }
 }


### PR DESCRIPTION
## Description

Add tabular two-sided CUSUM chart for detecting small, sustained
process shifts that Shewhart x-bar/R charts miss. Maintains running
C+/C- cumulative sums with reference value K and decision interval H;
reports the first alarm index where either series exceeds H. Includes
`DoubleArray`, `Iterable`, and `Sequence` overloads.

Closes #36

## Testing

`./gradlew :kstats-core:jvmTest --tests "org.oremif.kstats.descriptive.ControlChartTest"`
(116 tests, 46 new CUSUM tests covering the issue example, Montgomery
Table 9.2, property-based invariants, and edge cases)

## Checklist

- [x] Existing tests pass
- [x] New/updated tests for changed behavior
- [x] New/updated documentation if necessary