### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ data.skewness()           // => 0.3942
 
 ```kotlin
 dependencies {
-    implementation(platform("org.oremif:kstats-bom:0.4.0"))
+    implementation(platform("org.oremif:kstats-bom:0.5.0"))
     implementation("org.oremif:kstats-core")
     // add other modules as needed
 }
@@ -54,14 +54,14 @@ dependencies {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation(project.dependencies.platform("org.oremif:kstats-bom:0.4.0"))
+            implementation(project.dependencies.platform("org.oremif:kstats-bom:0.5.0"))
             implementation("org.oremif:kstats-core")
         }
     }
 }
 ```
 
-If you only need one module: `implementation("org.oremif:kstats-core:0.4.0")`.
+If you only need one module: `implementation("org.oremif:kstats-core:0.5.0")`.
 
 ## Modules
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,7 +4,7 @@
   "name": "kstats",
   "description": "Kotlin Multiplatform statistics toolkit for descriptive analysis, distributions, hypothesis testing, correlation, and sampling.",
   "variables": {
-    "kstats-version": "0.4.0"
+    "kstats-version": "0.5.0"
   },
   "colors": {
     "primary": "#29323D",
@@ -88,7 +88,7 @@
         "language": "en",
         "versions": [
           {
-            "version": "0.4.0",
+            "version": "0.5.0",
             "tabs": [
               {
                 "tab": "Documentation",
@@ -147,7 +147,7 @@
         "language": "de",
         "versions": [
           {
-            "version": "0.4.0",
+            "version": "0.5.0",
             "tabs": [
               {
                 "tab": "Dokumentation",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kstats = "0.4.0"
+kstats = "0.5.0"
 
 agp = "9.1.1"
 kotlin = "2.3.20"


### PR DESCRIPTION
## Description

Bump library version from 0.4.0 to 0.5.0 in preparation for the 0.5.0 release. Updates the version in `gradle/libs.versions.toml`, README installation snippets, and Mintlify docs (EN + DE locales).

## Testing

No behavioral change; existing tests apply.

## Checklist

- [x] Existing tests pass
- [ ] New/updated tests for changed behavior
- [x] New/updated documentation if necessary