### PR TITLE
chore: clean up redundant syntax and unused code

### DIFF
--- a/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/LongExtensions.kt
+++ b/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/LongExtensions.kt
@@ -160,7 +160,7 @@ public fun Iterable<Long>.describe(): DescriptiveStatistics = toStatArray().desc
  * @param lsl the lower specification limit. Must be less than [usl].
  * @param usl the upper specification limit. Must be greater than [lsl].
  * @return a [ProcessCapabilityResult] containing Cp, Cpk, Pp, and Ppk.
- * @throws DegenerateDataException if all values are identical (standard deviation is zero).
+ * @throws org.oremif.kstats.core.exceptions.DegenerateDataException if all values are identical (standard deviation is zero).
  */
 @JvmName("processCapabilityOfLong")
 public fun Iterable<Long>.processCapability(lsl: Double, usl: Double): ProcessCapabilityResult =

--- a/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/NumberExtensions.kt
+++ b/kstats-core/src/commonMain/kotlin/org/oremif/kstats/descriptive/NumberExtensions.kt
@@ -151,7 +151,7 @@ public fun Iterable<Int>.describe(): DescriptiveStatistics = toStatArray().descr
  * @param lsl the lower specification limit. Must be less than [usl].
  * @param usl the upper specification limit. Must be greater than [lsl].
  * @return a [ProcessCapabilityResult] containing Cp, Cpk, Pp, and Ppk.
- * @throws DegenerateDataException if all values are identical (standard deviation is zero).
+ * @throws org.oremif.kstats.core.exceptions.DegenerateDataException if all values are identical (standard deviation is zero).
  */
 @JvmName("processCapabilityOfInt")
 public fun Iterable<Int>.processCapability(lsl: Double, usl: Double): ProcessCapabilityResult =

--- a/kstats-core/src/commonTest/kotlin/org/oremif/kstats/descriptive/ControlChartTest.kt
+++ b/kstats-core/src/commonTest/kotlin/org/oremif/kstats/descriptive/ControlChartTest.kt
@@ -1206,14 +1206,14 @@ internal class ControlChartTest {
     @Test
     fun testCusumEmptyIterable() {
         assertFailsWith<InsufficientDataException> {
-            cusum(emptyList<Double>(), target = 0.0, k = 0.5, h = 5.0)
+            cusum(emptyList(), target = 0.0, k = 0.5, h = 5.0)
         }
     }
 
     @Test
     fun testCusumEmptySequence() {
         assertFailsWith<InsufficientDataException> {
-            cusum(emptySequence<Double>(), target = 0.0, k = 0.5, h = 5.0)
+            cusum(emptySequence(), target = 0.0, k = 0.5, h = 5.0)
         }
     }
 
@@ -1849,14 +1849,14 @@ internal class ControlChartTest {
     @Test
     fun testEwmaEmptyIterable() {
         assertFailsWith<InsufficientDataException> {
-            ewma(emptyList<Double>(), target = 0.0, sigma = 1.0, lambda = 0.2, controlLimitWidth = 3.0)
+            ewma(emptyList(), target = 0.0, sigma = 1.0, lambda = 0.2, controlLimitWidth = 3.0)
         }
     }
 
     @Test
     fun testEwmaEmptySequence() {
         assertFailsWith<InsufficientDataException> {
-            ewma(emptySequence<Double>(), target = 0.0, sigma = 1.0, lambda = 0.2, controlLimitWidth = 3.0)
+            ewma(emptySequence(), target = 0.0, sigma = 1.0, lambda = 0.2, controlLimitWidth = 3.0)
         }
     }
 
@@ -2293,7 +2293,7 @@ internal class ControlChartTest {
         assertTrue(
             result.outOfControl.contentEquals(expected.toIntArray()),
             "outOfControl should be exactly {i : z[i] ∉ [lcl[i], ucl[i]]}, " +
-                "expected ${expected} got ${result.outOfControl.toList()}"
+                "expected $expected got ${result.outOfControl.toList()}"
         )
     }
 
@@ -2796,14 +2796,14 @@ internal class ControlChartTest {
     @Test
     fun testWesternElectricRulesEmptyIterable() {
         assertFailsWith<InsufficientDataException> {
-            westernElectricRules(emptyList<Double>(), center = 0.0, sigma = 1.0)
+            westernElectricRules(emptyList(), center = 0.0, sigma = 1.0)
         }
     }
 
     @Test
     fun testWesternElectricRulesEmptySequence() {
         assertFailsWith<InsufficientDataException> {
-            westernElectricRules(emptySequence<Double>(), center = 0.0, sigma = 1.0)
+            westernElectricRules(emptySequence(), center = 0.0, sigma = 1.0)
         }
     }
 
@@ -3081,7 +3081,7 @@ internal class ControlChartTest {
         // enough consecutive 3σ violations, rule 2 must fire at some point too.
         val obs = doubleArrayOf(3.5, 3.5, 3.5, 3.5, 3.5)
         val r = westernElectricRules(obs, center = 0.0, sigma = 1.0)
-        assertTrue(r.rule1.size == 5, "All 5 are beyond 3σ")
+        assertEquals(r.rule1.size, 5, "All 5 are beyond 3σ")
         assertTrue(r.rule2.isNotEmpty(), "Consecutive 3σ alarms must also trigger rule 2")
         assertTrue(r.rule3.isNotEmpty(), "5 consecutive 3σ alarms must also trigger rule 3")
     }

--- a/kstats-core/src/commonTest/kotlin/org/oremif/kstats/descriptive/SemiVarianceTest.kt
+++ b/kstats-core/src/commonTest/kotlin/org/oremif/kstats/descriptive/SemiVarianceTest.kt
@@ -141,7 +141,6 @@ class SemiVarianceTest {
         val n = 1000
         val base = 1e15
         val arr = DoubleArray(n) { base + it.toDouble() }
-        val mean = arr.mean()
         val down = arr.semiVariance(direction = SemiVarianceDirection.DOWNSIDE)
         val up = arr.semiVariance(direction = SemiVarianceDirection.UPSIDE)
         // downside + upside must equal sample variance

--- a/kstats-correlation/src/commonTest/kotlin/org/oremif/kstats/correlation/KendallTauTest.kt
+++ b/kstats-correlation/src/commonTest/kotlin/org/oremif/kstats/correlation/KendallTauTest.kt
@@ -315,9 +315,9 @@ class KendallTauTest {
 
         // Brute-force calculation
         val n = x.size
-        var con = 0;
-        var disc = 0;
-        var tx = 0;
+        var con = 0
+        var disc = 0
+        var tx = 0
         var ty = 0
         for (i in 0 until n) {
             for (j in i + 1 until n) {

--- a/kstats-correlation/src/commonTest/kotlin/org/oremif/kstats/correlation/PartialCorrelationTest.kt
+++ b/kstats-correlation/src/commonTest/kotlin/org/oremif/kstats/correlation/PartialCorrelationTest.kt
@@ -87,7 +87,7 @@ class PartialCorrelationTest {
         // partialCorrelation(x, y, *emptyArray()) should delegate to Pearson
         val x = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0)
         val y = doubleArrayOf(2.0, 4.0, 6.0, 8.0, 10.0)
-        val partial = partialCorrelation(x, y, *emptyArray())
+        val partial = partialCorrelation(x, y)
         val pearson = pearsonCorrelation(x, y)
         assertEquals(pearson.coefficient, partial.coefficient, tol)
         assertEquals(pearson.pValue, partial.pValue, tol)

--- a/kstats-distributions/src/commonTest/kotlin/org/oremif/kstats/distributions/DistributionTest.kt
+++ b/kstats-distributions/src/commonTest/kotlin/org/oremif/kstats/distributions/DistributionTest.kt
@@ -318,7 +318,7 @@ class DistributionTest {
 
     @Test
     fun sampleProducesFiniteValues() {
-        val distributions = listOf<Pair<String, ContinuousDistribution>>(
+        val distributions = listOf(
             "Normal" to NormalDistribution.STANDARD,
             "Exponential" to ExponentialDistribution.STANDARD,
             "Laplace" to LaplaceDistribution.STANDARD,
@@ -338,7 +338,7 @@ class DistributionTest {
 
     @Test
     fun continuousNaNPropagation() {
-        val distributions = listOf<Pair<String, ContinuousDistribution>>(
+        val distributions = listOf(
             "Exponential" to ExponentialDistribution.STANDARD,
             "Normal" to NormalDistribution.STANDARD,
         )

--- a/kstats-hypothesis/src/commonMain/kotlin/org/oremif/kstats/hypothesis/NonParametric.kt
+++ b/kstats-hypothesis/src/commonMain/kotlin/org/oremif/kstats/hypothesis/NonParametric.kt
@@ -56,7 +56,6 @@ public fun mannWhitneyUTest(
     for (i in 0 until n1) r1 += ranks[i]
     val u1 = r1 - n1 * (n1 + 1.0) / 2.0
     val u2 = n1.toDouble() * n2 - u1
-    val u = minOf(u1, u2)
 
     // Normal approximation with tie correction
     val mu = n1.toDouble() * n2 / 2.0

--- a/kstats-hypothesis/src/commonTest/kotlin/org/oremif/kstats/hypothesis/PowerAnalysisTest.kt
+++ b/kstats-hypothesis/src/commonTest/kotlin/org/oremif/kstats/hypothesis/PowerAnalysisTest.kt
@@ -1,7 +1,6 @@
 package org.oremif.kstats.hypothesis
 
 import org.oremif.kstats.core.exceptions.InvalidParameterException
-import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/kstats-hypothesis/src/commonTest/kotlin/org/oremif/kstats/hypothesis/ProportionZTestTest.kt
+++ b/kstats-hypothesis/src/commonTest/kotlin/org/oremif/kstats/hypothesis/ProportionZTestTest.kt
@@ -490,7 +490,6 @@ class ProportionZTestTest {
     @Test
     fun testTwoSampleKnownValuesAllAlternatives() {
         // scipy: 60/100 vs 40/100
-        val two = proportionZTest(successes1 = 60, trials1 = 100, successes2 = 40, trials2 = 100)
         val less = proportionZTest(
             successes1 = 60, trials1 = 100, successes2 = 40, trials2 = 100,
             alternative = Alternative.LESS

--- a/kstats-hypothesis/src/commonTest/kotlin/org/oremif/kstats/hypothesis/samples/DocsSamples.kt
+++ b/kstats-hypothesis/src/commonTest/kotlin/org/oremif/kstats/hypothesis/samples/DocsSamples.kt
@@ -137,7 +137,7 @@ class DocsSamples {
         assertEquals(4.0, result.degreesOfFreedom, 1e-4)
         assertEquals(true, result.isSignificant())
         assertEquals(5.02, result.confidenceInterval!!.lower, 0.01)
-        assertEquals(6.98, result.confidenceInterval!!.upper, 0.01)
+        assertEquals(6.98, result.confidenceInterval.upper, 0.01)
     }
 
     @Test

--- a/kstats-sampling/src/commonTest/kotlin/org/oremif/kstats/sampling/BootstrapTest.kt
+++ b/kstats-sampling/src/commonTest/kotlin/org/oremif/kstats/sampling/BootstrapTest.kt
@@ -728,7 +728,7 @@ class BootstrapTest {
         // Verify bootstrapCI works with a custom statistic (standard deviation)
         val data = doubleArrayOf(2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0)
         val observedStd = sqrt(
-            data.map { (it - data.average()) * (it - data.average()) }.sum() / (data.size - 1)
+            data.sumOf { (it - data.average()) * (it - data.average()) } / (data.size - 1)
         )
 
         val result = bootstrapCI(
@@ -738,7 +738,7 @@ class BootstrapTest {
             random = Random(42),
             statistic = { arr ->
                 val mean = arr.average()
-                sqrt(arr.map { (it - mean) * (it - mean) }.sum() / (arr.size - 1))
+                sqrt(arr.sumOf { (it - mean) * (it - mean) } / (arr.size - 1))
             },
         )
 

--- a/kstats-sampling/src/commonTest/kotlin/org/oremif/kstats/sampling/samples/DocsSamples.kt
+++ b/kstats-sampling/src/commonTest/kotlin/org/oremif/kstats/sampling/samples/DocsSamples.kt
@@ -1,8 +1,6 @@
 package org.oremif.kstats.sampling.samples
 
 import org.oremif.kstats.sampling.*
-import org.oremif.kstats.descriptive.Frequency
-import org.oremif.kstats.descriptive.toFrequency
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -174,8 +172,8 @@ class DocsSamples {
 
     @Test
     fun edaFrequencyDistribution() {
-        val responseTimeMs = DocsSamples.responseTimeMs
-        val errorsPerHour = DocsSamples.errorsPerHour
+        val responseTimeMs = responseTimeMs
+        val errorsPerHour = errorsPerHour
         // SampleStart
         val rtBins = responseTimeMs.frequencyTable(binCount = 5)
         rtBins.forEach { bin ->
@@ -191,9 +189,9 @@ class DocsSamples {
 
     @Test
     fun edaNormalizeRank() {
-        val responseTimeMs = DocsSamples.responseTimeMs
-        val memoryUsageMb = DocsSamples.memoryUsageMb
-        val throughputRps = DocsSamples.throughputRps
+        val responseTimeMs = responseTimeMs
+        val memoryUsageMb = memoryUsageMb
+        val throughputRps = throughputRps
         // SampleStart
         // Z-score: values become standard deviations from mean
         val rtNormalized = responseTimeMs.zScore()


### PR DESCRIPTION
## Description

Housekeeping pass across modules: drop redundant type arguments, remove unused locals and imports, replace `map{}.sum()` with `sumOf{}` in bootstrap tests, and fully qualify `DegenerateDataException` in `@throws` tags so Dokka can link it. No behavioral changes.

## Testing

`./gradlew allTests`

## Checklist

- [x] Existing tests pass
- [x] New/updated tests for changed behavior
- [x] New/updated documentation if necessary